### PR TITLE
chore: add only `bin` folder to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
   "license": "ISC",
   "engines": {
     "node": ">=14.0.0"
-  }
+  },
+  "files": [
+    "bin"
+  ]
 }


### PR DESCRIPTION
the same was as sdk does: https://github.com/aeternity/aepp-sdk-js/blob/0478eed0a86b959e62b8b63a261711ec18888d90/package.json#L112-L116

npm will also pick `LICENSE`, `README.md`, and `package.json`