### PR TITLE
feat: add select-node, select-compiler commands

### DIFF
--- a/CLI.md
+++ b/CLI.md
@@ -28,32 +28,24 @@ The command-line interface is invoked using the command `aecli`. Depending on wh
 
 If you invoke `aecli` with no arguments, it shows basic usage:
 ```
-$ ./aecli
-The command line client for the Aeternity blockchain
+$ aecli
+Usage: aecli [options] [command]
 
-Usage:
-  aecli [command]
+Options:
+  -V, --version   output the version number
+  -h, --help      display help for command
 
-Available Commands:
-  chain       Query the state of the chain
-  config      Print the configuration of the sdk
-  help        Help concerning any command
-  inspect     Inspect an object of the blockchain
-  name        A brief description of your command
-  account     Handle wallet operations
-  contract    Compile contracts
-  crypto      Crypto helpers
-
-
-Flags:
-  -c, --config string   config file to load (defaults to $HOME/.aeternity/config.yaml
-      --debug           enable debug
-  -h, --help            help for aecli
-      --json            print output in json format
-      --version         version for aecli
-  -u, --epoch-url,      show URL of epoch
-
-Use "aecli [command] --help" for more information about a command.
+Commands:
+  config          Print the sdk default configuration
+  chain           Interact with the blockchain
+  inspect         Get information on transactions, blocks,...
+  account         Handle wallet operations
+  contract        Compile contracts
+  name            AENS system
+  tx              Transaction builder
+  oracle          Interact with oracles
+  crypto          Crypto helpers
+  help [command]  display help for command
 ```
 
 The general groupings of commands are:
@@ -263,7 +255,7 @@ $ ./aecli.mjs  contract
 
     -H, --host [hostname]             Node to connect to (default: https://localhost:3013)
     -T, --ttl [ttl]                   Validity of the transaction in number of blocks (default forever) (default: 50000)
-    -f --force                        Ignore epoch version compatibility check
+    -f --force                        Ignore node version compatibility check
     --json [json]                     Print result in json format
     -h, --help                        output usage information
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@aeternity/aepp-sdk": "^12.1.2",
         "bignumber.js": "^9.1.0",
         "commander": "^9.3.0",
+        "env-paths": "^2.2.1",
         "fs-extra": "^10.1.0",
         "prompts": "^2.4.2"
       },
@@ -4234,6 +4235,14 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -12383,6 +12392,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="
     },
     "error-ex": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@aeternity/aepp-sdk": "^12.1.2",
     "bignumber.js": "^9.1.0",
     "commander": "^9.3.0",
+    "env-paths": "^2.2.1",
     "fs-extra": "^10.1.0",
     "prompts": "^2.4.2"
   },

--- a/src/arguments.js
+++ b/src/arguments.js
@@ -26,3 +26,5 @@ export const gasOption = new Option('-G --gas [gas]', 'Amount of gas to call/dep
   .argParser((gas) => +gas);
 
 export const forceOption = new Option('-f --force', 'Ignore node version compatibility check');
+
+export const passwordOption = new Option('-P, --password [password]', 'Wallet Password');

--- a/src/arguments.js
+++ b/src/arguments.js
@@ -32,3 +32,5 @@ export const passwordOption = new Option('-P, --password [password]', 'Wallet Pa
 
 export const ttlOption = new Option('-T, --ttl [ttl]', 'Validity of the transaction in number of blocks')
   .default(TX_TTL, 'forever');
+
+export const networkIdOption = new Option('--networkId [networkId]', 'Network id');

--- a/src/arguments.js
+++ b/src/arguments.js
@@ -1,5 +1,6 @@
 import { Argument, Option } from 'commander';
 import BigNumber from 'bignumber.js';
+import { TX_TTL } from '@aeternity/aepp-sdk';
 import { NODE_URL, COMPILER_URL } from './utils/constant';
 
 export const coinAmountParser = (amount) => (
@@ -28,3 +29,6 @@ export const gasOption = new Option('-G --gas [gas]', 'Amount of gas to call/dep
 export const forceOption = new Option('-f --force', 'Ignore node version compatibility check');
 
 export const passwordOption = new Option('-P, --password [password]', 'Wallet Password');
+
+export const ttlOption = new Option('-T, --ttl [ttl]', 'Validity of the transaction in number of blocks')
+  .default(TX_TTL, 'forever');

--- a/src/arguments.js
+++ b/src/arguments.js
@@ -1,6 +1,6 @@
 import { Argument, Option } from 'commander';
 import BigNumber from 'bignumber.js';
-import { NODE_URL } from './utils/constant';
+import { NODE_URL, COMPILER_URL } from './utils/constant';
 
 export const coinAmountParser = (amount) => (
   new BigNumber(amount.replace(/ae$/, '')).shiftedBy(amount.endsWith('ae') ? 18 : 0)
@@ -12,8 +12,13 @@ export const feeOption = new Option('-F, --fee [fee]', 'Override the transaction
 export const nonceArgument = new Argument('<nonce>', 'Unique number that is required to sign transaction securely')
   .argParser((nonce) => +nonce);
 
-export const nodeOption = new Option('-u, --url [hostname]', 'Node to connect to')
-  .default(NODE_URL, 'Aeternity testnet');
+export const nodeOption = new Option('-u, --url [nodeUrl]', 'Node to connect to')
+  .default(NODE_URL, 'Aeternity testnet')
+  .env('AECLI_NODE_URL');
+
+export const compilerOption = new Option('--compilerUrl [compilerUrl]', 'Compiler to connect to')
+  .default(COMPILER_URL, 'Stable compiler')
+  .env('AECLI_COMPILER_URL');
 
 export const jsonOption = new Option('--json', 'Print result in json format');
 

--- a/src/arguments.js
+++ b/src/arguments.js
@@ -24,3 +24,5 @@ export const jsonOption = new Option('--json', 'Print result in json format');
 
 export const gasOption = new Option('-G --gas [gas]', 'Amount of gas to call/deploy the contract')
   .argParser((gas) => +gas);
+
+export const forceOption = new Option('-f --force', 'Ignore node version compatibility check');

--- a/src/commands/account.js
+++ b/src/commands/account.js
@@ -23,7 +23,7 @@ import { TX_TTL } from '@aeternity/aepp-sdk';
 import { withGlobalOpts } from '../utils/cli';
 import * as Account from '../actions/account';
 import {
-  nodeOption, jsonOption, coinAmountParser, feeOption,
+  nodeOption, jsonOption, coinAmountParser, feeOption, forceOption,
 } from '../arguments';
 
 const program = new Command().name('aecli account');
@@ -32,7 +32,7 @@ const program = new Command().name('aecli account');
 program
   .addOption(nodeOption)
   .option('-P, --password [password]', 'Wallet Password')
-  .option('-f --force', 'Ignore epoch version compatibility check')
+  .addOption(forceOption)
   .addOption(jsonOption);
 
 // ## Initialize `spend` command

--- a/src/commands/account.js
+++ b/src/commands/account.js
@@ -20,7 +20,7 @@
 // We'll use `commander` for parsing options
 import { Command } from 'commander';
 import { TX_TTL } from '@aeternity/aepp-sdk';
-import { getCmdFromArguments } from '../utils/cli';
+import { withGlobalOpts } from '../utils/cli';
 import * as Account from '../actions/account';
 import {
   nodeOption, jsonOption, coinAmountParser, feeOption,
@@ -54,7 +54,7 @@ program
   .addOption(feeOption)
   .option('-T, --ttl [ttl]', 'Validity of the spend transaction in number of blocks (default forever)', TX_TTL)
   .option('-N, --nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
-  .action((walletPath, receiverIdOrName, amount, ...args) => Account.spend(walletPath, receiverIdOrName, amount, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Account.spend));
 
 // ## Initialize `transfer` command
 //
@@ -74,7 +74,7 @@ program
   .addOption(feeOption)
   .option('-T, --ttl [ttl]', 'Validity of the spend transaction in number of blocks (default forever)', TX_TTL)
   .option('-N, --nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
-  .action((walletPath, receiver, percentage, ...args) => Account.transferFunds(walletPath, receiver, percentage, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Account.transferFunds));
 
 // ## Initialize `sign` command
 //
@@ -85,7 +85,7 @@ program
   .command('sign <wallet_path> <tx>')
   .option('--networkId [networkId]', 'Network id (default: ae_mainnet)')
   .description('Create a transaction to another wallet')
-  .action((walletPath, tx, ...args) => Account.sign(walletPath, tx, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Account.sign));
 
 // ## Initialize `sign-message` command
 //
@@ -96,7 +96,7 @@ program
   .command('sign-message <wallet_path> [data...]')
   .option('--filePath [path]', 'Specify the path to the file for signing(ignore command message argument and use file instead)')
   .description('Create a transaction to another wallet')
-  .action((walletPath, data, ...args) => Account.signMessage(walletPath, data, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Account.signMessage));
 
 // ## Initialize `verify-message` command
 //
@@ -107,7 +107,7 @@ program
   .command('verify-message <wallet_path> <hexSignature> [data...]')
   .option('--filePath [path]', 'Specify the path to the file(ignore comm and message argument and use file instead)')
   .description('Create a transaction to another wallet')
-  .action((walletPath, hexSignature, data, ...args) => Account.verifyMessage(walletPath, hexSignature, data, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Account.verifyMessage));
 
 // ## Initialize `balance` command
 //
@@ -119,7 +119,7 @@ program
   .option('--height [height]', 'Specific block height')
   .option('--hash [hash]', 'Specific block hash')
   .description('Get wallet balance')
-  .action((walletPath, ...args) => Account.getBalance(walletPath, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Account.getBalance));
 
 // ## Initialize `address` command
 //
@@ -133,7 +133,7 @@ program
   .option('--privateKey', 'Print private key')
   .option('--forcePrompt', 'Force prompting')
   .description('Get wallet address')
-  .action((walletPath, ...args) => Account.getAddress(walletPath, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Account.getAddress));
 
 // ## Initialize `create` command
 //
@@ -150,7 +150,7 @@ program
   .option('-O, --output [output]', 'Output directory', '.')
   .option('--overwrite', 'Overwrite if exist')
   .description('Create a secure wallet')
-  .action((walletPath, ...args) => Account.createSecureWallet(walletPath, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Account.createSecureWallet));
 
 // ## Initialize `save` command
 //
@@ -167,7 +167,7 @@ program
   .option('-O, --output [output]', 'Output directory', '.')
   .option('--overwrite', 'Overwrite if exist')
   .description('Save a private keys string to a password protected file wallet')
-  .action((walletPath, priv, ...args) => Account.createSecureWalletByPrivKey(walletPath, priv, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Account.createSecureWalletByPrivKey));
 
 // ## Initialize `nonce` command
 //
@@ -179,7 +179,7 @@ program
 program
   .command('nonce <wallet_path>')
   .description('Get account nonce')
-  .action((walletPath, ...args) => Account.getAccountNonce(walletPath, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Account.getAccountNonce));
 
 // ## Initialize `generateKeyPairs` command
 //
@@ -190,6 +190,6 @@ program
   .command('generate <count>')
   .option('--forcePrompt', 'Force prompting')
   .description('Generate keyPairs')
-  .action((count, ...args) => Account.generateKeyPairs(count, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Account.generateKeyPairs));
 
 export default program;

--- a/src/commands/account.js
+++ b/src/commands/account.js
@@ -19,7 +19,6 @@
  */
 // We'll use `commander` for parsing options
 import { Command } from 'commander';
-import { withGlobalOpts } from '../utils/cli';
 import * as Account from '../actions/account';
 import {
   nodeOption,
@@ -35,7 +34,7 @@ import {
 const program = new Command().name('aecli account');
 
 // ## Initialize `options`
-program
+const addCommonOptions = (p) => p
   .addOption(nodeOption)
   .addOption(passwordOption)
   .addOption(forceOption)
@@ -52,7 +51,7 @@ program
 // You can set transaction `ttl(Time to leave)`. If not set use default.
 //
 // Example: `aecli account spend ./myWalletKeyFile ak_1241rioefwj23f2wfdsfsdsdfsasdf 100 --password testpassword --ttl 20` --> this tx will leave for 20 blocks
-program
+addCommonOptions(program
   .command('spend <wallet_path> <receiverIdOrName>')
   .argument('<amount>', 'Amount of coins to send in aettos or in ae (example: 1.2ae)', coinAmountParser)
   .addOption(networkIdOption)
@@ -60,7 +59,7 @@ program
   .addOption(feeOption)
   .addOption(ttlOption)
   .option('-N, --nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
-  .action(withGlobalOpts(Account.spend));
+  .action(Account.spend));
 
 // ## Initialize `transfer` command
 //
@@ -71,7 +70,7 @@ program
 // You can set transaction `ttl(Time to leave)`. If not set use default.
 //
 // Example: `aecli account transfer ./myWalletKeyFile ak_1241rioefwj23f2wfdsfsdsdfsasdf 0.5 --password testpassword --ttl 20` --> this tx will leave for 20 blocks
-program
+addCommonOptions(program
   .command('transfer <wallet_path>')
   .argument('<receiver>', 'Address or name of recipient account')
   .argument('<fraction>', 'Fraction of balance to spend (between 0 and 1)', (v) => +v)
@@ -80,52 +79,52 @@ program
   .addOption(feeOption)
   .addOption(ttlOption)
   .option('-N, --nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
-  .action(withGlobalOpts(Account.transferFunds));
+  .action(Account.transferFunds));
 
 // ## Initialize `sign` command
 //
 // You can use this command to sign your transaction's
 //
 // Example: `aecli account sign ./myWalletKeyFile tx_1241rioefwj23f2wfdsfsdsdfsasdf --password testpassword`
-program
+addCommonOptions(program
   .command('sign <wallet_path> <tx>')
   .addOption(networkIdOption)
   .description('Create a transaction to another wallet')
-  .action(withGlobalOpts(Account.sign));
+  .action(Account.sign));
 
 // ## Initialize `sign-message` command
 //
 // You can use this command to sign message
 //
 // Example: `aecli account sign-message ./myWalletKeyFile Hello --password testpassword`
-program
+addCommonOptions(program
   .command('sign-message <wallet_path> [data...]')
   .option('--filePath [path]', 'Specify the path to the file for signing(ignore command message argument and use file instead)')
   .description('Create a transaction to another wallet')
-  .action(withGlobalOpts(Account.signMessage));
+  .action(Account.signMessage));
 
 // ## Initialize `verify-message` command
 //
 // You can use this command to sign message
 //
 // Example: `aecli account verify-message ./myWalletKeyFile asd1dasfadfsdasdasdasHexSig... Hello --password testpassword`
-program
+addCommonOptions(program
   .command('verify-message <wallet_path> <hexSignature> [data...]')
   .option('--filePath [path]', 'Specify the path to the file(ignore comm and message argument and use file instead)')
   .description('Create a transaction to another wallet')
-  .action(withGlobalOpts(Account.verifyMessage));
+  .action(Account.verifyMessage));
 
 // ## Initialize `balance` command
 //
 // You can use this command to retrieve balance of account
 //
 // Example: `aecli account balance ./myWalletKeyFile --password testpassword`
-program
+addCommonOptions(program
   .command('balance <wallet_path>')
   .option('--height [height]', 'Specific block height')
   .option('--hash [hash]', 'Specific block hash')
   .description('Get wallet balance')
-  .action(withGlobalOpts(Account.getBalance));
+  .action(Account.getBalance));
 
 // ## Initialize `address` command
 //
@@ -134,12 +133,12 @@ program
 // Example: `aecli account address ./myWalletKeyFile --password testpassword` --> show only public key
 //
 // Example: `aecli account address ./myWalletKeyFile --password testpassword --privateKey` --> show  public key and private key
-program
+addCommonOptions(program
   .command('address <wallet_path>')
   .option('--privateKey', 'Print private key')
   .option('--forcePrompt', 'Force prompting')
   .description('Get wallet address')
-  .action(withGlobalOpts(Account.getAddress));
+  .action(Account.getAddress));
 
 // ## Initialize `create` command
 //
@@ -151,12 +150,12 @@ program
 // Example: `aecli account create myWalletName --password testpassword`
 //
 // Example: `aecli account create myWalletName --password testpassword --output ./mykeys` --> create `key-file` in `mykeys` directory
-program
+addCommonOptions(program
   .command('create <wallet_path>')
   .option('-O, --output [output]', 'Output directory', '.')
   .option('--overwrite', 'Overwrite if exist')
   .description('Create a secure wallet')
-  .action(withGlobalOpts(Account.createSecureWallet));
+  .action(Account.createSecureWallet));
 
 // ## Initialize `save` command
 //
@@ -168,12 +167,12 @@ program
 // Example: `aecli account save myWalletName 1902855723940510273412074210842018342148234  --password testpassword`
 //
 // Example: `aecli account save myWalletName 1902855723940510273412074210842018342148234 --password testpassword --output ./mykeys` --> create `key-file` in `mykeys` directory
-program
+addCommonOptions(program
   .command('save <wallet_path> <privkey>')
   .option('-O, --output [output]', 'Output directory', '.')
   .option('--overwrite', 'Overwrite if exist')
   .description('Save a private keys string to a password protected file wallet')
-  .action(withGlobalOpts(Account.createSecureWalletByPrivKey));
+  .action(Account.createSecureWalletByPrivKey));
 
 // ## Initialize `nonce` command
 //
@@ -182,20 +181,20 @@ program
 // You can use `--output ./keys` to set directory to save you key
 //
 // Example: `aecli account nonce myWalletName --password testpassword
-program
+addCommonOptions(program
   .command('nonce <wallet_path>')
   .description('Get account nonce')
-  .action(withGlobalOpts(Account.getAccountNonce));
+  .action(Account.getAccountNonce));
 
 // ## Initialize `generateKeyPairs` command
 //
 // You can use this command to generate KeyPair's.
 //
 // Example: `aecli account generate 10 --force
-program
+addCommonOptions(program
   .command('generate <count>')
   .option('--forcePrompt', 'Force prompting')
   .description('Generate keyPairs')
-  .action(withGlobalOpts(Account.generateKeyPairs));
+  .action(Account.generateKeyPairs));
 
 export default program;

--- a/src/commands/account.js
+++ b/src/commands/account.js
@@ -19,11 +19,10 @@
  */
 // We'll use `commander` for parsing options
 import { Command } from 'commander';
-import { TX_TTL } from '@aeternity/aepp-sdk';
 import { withGlobalOpts } from '../utils/cli';
 import * as Account from '../actions/account';
 import {
-  nodeOption, jsonOption, coinAmountParser, feeOption, forceOption, passwordOption,
+  nodeOption, jsonOption, coinAmountParser, feeOption, forceOption, passwordOption, ttlOption,
 } from '../arguments';
 
 const program = new Command().name('aecli account');
@@ -52,7 +51,7 @@ program
   .option('--networkId [networkId]', 'Network id (default: ae_mainnet)')
   .option('--payload [payload]', 'Transaction payload.', '')
   .addOption(feeOption)
-  .option('-T, --ttl [ttl]', 'Validity of the spend transaction in number of blocks (default forever)', TX_TTL)
+  .addOption(ttlOption)
   .option('-N, --nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
   .action(withGlobalOpts(Account.spend));
 
@@ -72,7 +71,7 @@ program
   .option('--networkId [networkId]', 'Network id (default: ae_mainnet)')
   .option('--payload [payload]', 'Transaction payload.', '')
   .addOption(feeOption)
-  .option('-T, --ttl [ttl]', 'Validity of the spend transaction in number of blocks (default forever)', TX_TTL)
+  .addOption(ttlOption)
   .option('-N, --nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
   .action(withGlobalOpts(Account.transferFunds));
 

--- a/src/commands/account.js
+++ b/src/commands/account.js
@@ -22,7 +22,14 @@ import { Command } from 'commander';
 import { withGlobalOpts } from '../utils/cli';
 import * as Account from '../actions/account';
 import {
-  nodeOption, jsonOption, coinAmountParser, feeOption, forceOption, passwordOption, ttlOption,
+  nodeOption,
+  jsonOption,
+  coinAmountParser,
+  feeOption,
+  forceOption,
+  passwordOption,
+  ttlOption,
+  networkIdOption,
 } from '../arguments';
 
 const program = new Command().name('aecli account');
@@ -48,7 +55,7 @@ program
 program
   .command('spend <wallet_path> <receiverIdOrName>')
   .argument('<amount>', 'Amount of coins to send in aettos or in ae (example: 1.2ae)', coinAmountParser)
-  .option('--networkId [networkId]', 'Network id (default: ae_mainnet)')
+  .addOption(networkIdOption)
   .option('--payload [payload]', 'Transaction payload.', '')
   .addOption(feeOption)
   .addOption(ttlOption)
@@ -68,7 +75,7 @@ program
   .command('transfer <wallet_path>')
   .argument('<receiver>', 'Address or name of recipient account')
   .argument('<fraction>', 'Fraction of balance to spend (between 0 and 1)', (v) => +v)
-  .option('--networkId [networkId]', 'Network id (default: ae_mainnet)')
+  .addOption(networkIdOption)
   .option('--payload [payload]', 'Transaction payload.', '')
   .addOption(feeOption)
   .addOption(ttlOption)
@@ -82,7 +89,7 @@ program
 // Example: `aecli account sign ./myWalletKeyFile tx_1241rioefwj23f2wfdsfsdsdfsasdf --password testpassword`
 program
   .command('sign <wallet_path> <tx>')
-  .option('--networkId [networkId]', 'Network id (default: ae_mainnet)')
+  .addOption(networkIdOption)
   .description('Create a transaction to another wallet')
   .action(withGlobalOpts(Account.sign));
 

--- a/src/commands/account.js
+++ b/src/commands/account.js
@@ -23,7 +23,7 @@ import { TX_TTL } from '@aeternity/aepp-sdk';
 import { withGlobalOpts } from '../utils/cli';
 import * as Account from '../actions/account';
 import {
-  nodeOption, jsonOption, coinAmountParser, feeOption, forceOption,
+  nodeOption, jsonOption, coinAmountParser, feeOption, forceOption, passwordOption,
 } from '../arguments';
 
 const program = new Command().name('aecli account');
@@ -31,7 +31,7 @@ const program = new Command().name('aecli account');
 // ## Initialize `options`
 program
   .addOption(nodeOption)
-  .option('-P, --password [password]', 'Wallet Password')
+  .addOption(passwordOption)
   .addOption(forceOption)
   .addOption(jsonOption);
 

--- a/src/commands/chain.js
+++ b/src/commands/chain.js
@@ -19,7 +19,7 @@
  */
 // We'll use `commander` for parsing options
 import { Command } from 'commander';
-import { getCmdFromArguments } from '../utils/cli';
+import { withGlobalOpts } from '../utils/cli';
 import * as Chain from '../actions/chain';
 import { nodeOption, jsonOption } from '../arguments';
 
@@ -40,7 +40,7 @@ program
 program
   .command('top')
   .description('Get top of Chain')
-  .action((...args) => Chain.top(getCmdFromArguments(args)));
+  .action(withGlobalOpts(Chain.top));
 
 // ## Initialize `status` command
 //
@@ -50,7 +50,7 @@ program
 program
   .command('status')
   .description('Get node version')
-  .action((...args) => Chain.version(getCmdFromArguments(args)));
+  .action(withGlobalOpts(Chain.version));
 
 // ## Initialize `ttl` command
 //
@@ -60,7 +60,7 @@ program
 program
   .command('ttl <absoluteTtl>')
   .description('Get relative ttl')
-  .action((absoluteTtl, ...args) => Chain.ttl(absoluteTtl, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Chain.ttl));
 
 // ## Initialize `ttl` command
 //
@@ -70,7 +70,7 @@ program
 program
   .command('network_id')
   .description('Get network ID')
-  .action((...args) => Chain.getNetworkId(getCmdFromArguments(args)));
+  .action(withGlobalOpts(Chain.getNetworkId));
 
 // ## Initialize `play` command
 //
@@ -83,7 +83,7 @@ program
   .command('play')
   .option('-P --height [playToHeight]', 'Play to selected height')
   .description('Real-time block monitoring')
-  .action((...args) => Chain.play(getCmdFromArguments(args)));
+  .action(withGlobalOpts(Chain.play));
 
 // ## Initialize `broadcast` command
 //
@@ -95,6 +95,6 @@ program
   .option('-W, --no-waitMined', 'Force waiting until transaction will be mined')
   .option('--verify', 'Verify Transaction before broadcast.')
   .description('Send transaction to the chain')
-  .action((tx, ...args) => Chain.broadcast(tx, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Chain.broadcast));
 
 export default program;

--- a/src/commands/chain.js
+++ b/src/commands/chain.js
@@ -19,14 +19,13 @@
  */
 // We'll use `commander` for parsing options
 import { Command } from 'commander';
-import { withGlobalOpts } from '../utils/cli';
 import * as Chain from '../actions/chain';
 import { nodeOption, jsonOption, forceOption } from '../arguments';
 
 const program = new Command().name('aecli chain');
 
-// # Initialize `options`
-program
+// ## Initialize `options`
+const addCommonOptions = (p) => p
   .addOption(nodeOption)
   .option('-L --limit [playlimit]', 'Limit for play command', 10)
   .addOption(forceOption)
@@ -37,40 +36,40 @@ program
 // You can use this command to retrieve `top block` from `node`
 //
 // Example: `aecli chain top`
-program
+addCommonOptions(program
   .command('top')
   .description('Get top of Chain')
-  .action(withGlobalOpts(Chain.top));
+  .action(Chain.top));
 
 // ## Initialize `status` command
 //
 // You can use this command to retrieve `node version`
 //
 // Example: `aecli chain status`
-program
+addCommonOptions(program
   .command('status')
   .description('Get node version')
-  .action(withGlobalOpts(Chain.version));
+  .action(Chain.version));
 
 // ## Initialize `ttl` command
 //
 // You can use this command to retrieve relative `ttl`
 //
 // Example: `aecli chain ttl <absolute_ttl>`
-program
+addCommonOptions(program
   .command('ttl <absoluteTtl>')
   .description('Get relative ttl')
-  .action(withGlobalOpts(Chain.ttl));
+  .action(Chain.ttl));
 
 // ## Initialize `ttl` command
 //
 // You can use this command to retrieve relative `ttl`
 //
 // Example: `aecli chain ttl <absolute_ttl>`
-program
+addCommonOptions(program
   .command('network_id')
   .description('Get network ID')
-  .action(withGlobalOpts(Chain.getNetworkId));
+  .action(Chain.getNetworkId));
 
 // ## Initialize `play` command
 //
@@ -79,22 +78,22 @@ program
 // Example: `aecli chain play --limit 10` --> print 10 blocks starting from top
 //
 // Example: `aecli chain play --height` --> print blocks until reach some height starting from top
-program
+addCommonOptions(program
   .command('play')
   .option('-P --height [playToHeight]', 'Play to selected height')
   .description('Real-time block monitoring')
-  .action(withGlobalOpts(Chain.play));
+  .action(Chain.play));
 
 // ## Initialize `broadcast` command
 //
 // You can use this command to send `transaction` to the `chain`
 //
 // Example: `aecli tx spend ak_2a1j2Mk9YSmC1gioUq4PWRm3bsv887MbuRVwyv4KaUGoR1eiKi ak_AgV756Vfo99juwzNVgnjP1gXX1op1QN3NXTxvkPnHJPUDE8NT 100`
-program
+addCommonOptions(program
   .command('broadcast <tx>')
   .option('-W, --no-waitMined', 'Force waiting until transaction will be mined')
   .option('--verify', 'Verify Transaction before broadcast.')
   .description('Send transaction to the chain')
-  .action(withGlobalOpts(Chain.broadcast));
+  .action(Chain.broadcast));
 
 export default program;

--- a/src/commands/chain.js
+++ b/src/commands/chain.js
@@ -21,7 +21,7 @@
 import { Command } from 'commander';
 import { withGlobalOpts } from '../utils/cli';
 import * as Chain from '../actions/chain';
-import { nodeOption, jsonOption } from '../arguments';
+import { nodeOption, jsonOption, forceOption } from '../arguments';
 
 const program = new Command().name('aecli chain');
 
@@ -29,7 +29,7 @@ const program = new Command().name('aecli chain');
 program
   .addOption(nodeOption)
   .option('-L --limit [playlimit]', 'Limit for play command', 10)
-  .option('-f --force', 'Ignore node version compatibility check')
+  .addOption(forceOption)
   .addOption(jsonOption);
 
 // ## Initialize `top` command

--- a/src/commands/contract.js
+++ b/src/commands/contract.js
@@ -24,7 +24,7 @@ import { withGlobalOpts } from '../utils/cli';
 import CliError from '../utils/CliError';
 import * as Contract from '../actions/contract';
 import {
-  nodeOption, compilerOption, jsonOption, gasOption, feeOption, forceOption,
+  nodeOption, compilerOption, jsonOption, gasOption, feeOption, forceOption, passwordOption,
 } from '../arguments';
 
 const callArgs = new Argument('[args]', 'JSON-encoded arguments array of contract call')
@@ -116,7 +116,7 @@ program
   .addOption(contractAciFilenameOption)
   .option('-W, --no-waitMined', 'Force waiting until transaction will be mined')
   .option('--networkId [networkId]', 'Network id (default: ae_mainnet)')
-  .option('-P, --password [password]', 'Wallet Password')
+  .addOption(passwordOption)
   .addOption(gasOption)
   .option('-s --callStatic', 'Call static')
   .option('-t --topHash', 'Hash of block to make call')
@@ -145,7 +145,7 @@ program
   .addOption(contractAciFilenameOption)
   .option('--networkId [networkId]', 'Network id (default: ae_mainnet)')
   .option('-W, --no-waitMined', 'Force waiting until transaction will be mined')
-  .option('-P, --password [password]', 'Wallet Password')
+  .addOption(passwordOption)
   .addOption(gasOption)
   .option('-G --gasPrice [gas]', 'Amount of gas to deploy the contract', MIN_GAS_PRICE)
   .addOption(feeOption)

--- a/src/commands/contract.js
+++ b/src/commands/contract.js
@@ -19,12 +19,19 @@
  */
 // We'll use `commander` for parsing options
 import { Argument, Option, Command } from 'commander';
-import { TX_TTL, MIN_GAS_PRICE } from '@aeternity/aepp-sdk';
+import { MIN_GAS_PRICE } from '@aeternity/aepp-sdk';
 import { withGlobalOpts } from '../utils/cli';
 import CliError from '../utils/CliError';
 import * as Contract from '../actions/contract';
 import {
-  nodeOption, compilerOption, jsonOption, gasOption, feeOption, forceOption, passwordOption,
+  nodeOption,
+  compilerOption,
+  jsonOption,
+  gasOption,
+  feeOption,
+  forceOption,
+  passwordOption,
+  ttlOption,
 } from '../arguments';
 
 const callArgs = new Argument('[args]', 'JSON-encoded arguments array of contract call')
@@ -121,7 +128,7 @@ program
   .option('-s --callStatic', 'Call static')
   .option('-t --topHash', 'Hash of block to make call')
   .addOption(feeOption)
-  .option('-T, --ttl [ttl]', 'Validity of the spend transaction in number of blocks (default forever)', TX_TTL)
+  .addOption(ttlOption)
   .option('-N, --nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
   .description('Execute a function of the contract')
   .action(withGlobalOpts(Contract.call));
@@ -149,7 +156,7 @@ program
   .addOption(gasOption)
   .option('-G --gasPrice [gas]', 'Amount of gas to deploy the contract', MIN_GAS_PRICE)
   .addOption(feeOption)
-  .option('-T, --ttl [ttl]', 'Validity of the spend transaction in number of blocks (default forever)', TX_TTL)
+  .addOption(ttlOption)
   .option('-N, --nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
   .description('Deploy a contract on the chain')
   .action(withGlobalOpts(Contract.deploy));

--- a/src/commands/contract.js
+++ b/src/commands/contract.js
@@ -21,7 +21,7 @@
 import { Argument, Option, Command } from 'commander';
 import { TX_TTL, MIN_GAS_PRICE } from '@aeternity/aepp-sdk';
 import { COMPILER_URL } from '../utils/constant';
-import { getCmdFromArguments } from '../utils/cli';
+import { withGlobalOpts } from '../utils/cli';
 import CliError from '../utils/CliError';
 import * as Contract from '../actions/contract';
 import {
@@ -62,7 +62,7 @@ program
 program
   .command('compile <file>')
   .description('Compile a contract')
-  .action((file, ...args) => Contract.compile(file, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Contract.compile));
 
 // ## Initialize `encode-calldata` command
 //
@@ -76,7 +76,7 @@ program
   .addOption(contractSourceFilenameOption)
   .addOption(contractAciFilenameOption)
   .description('Encode contract calldata')
-  .action((fn, args, ...otherArgs) => Contract.encodeCalldata(fn, args, getCmdFromArguments(otherArgs)));
+  .action(withGlobalOpts(Contract.encodeCalldata));
 
 // ## Initialize `decode-calldata` command
 //
@@ -90,7 +90,7 @@ program
   .addOption(contractSourceFilenameOption)
   .addOption(contractAciFilenameOption)
   .description('Decode contract calldata')
-  .action((fn, data, ...args) => Contract.decodeCallResult(fn, data, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Contract.decodeCallResult));
 
 // ## Initialize `call` command
 //
@@ -125,7 +125,7 @@ program
   .option('-T, --ttl [ttl]', 'Validity of the spend transaction in number of blocks (default forever)', TX_TTL)
   .option('-N, --nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
   .description('Execute a function of the contract')
-  .action((walletPath, fn, args, ...otherArgs) => Contract.call(walletPath, fn, args, getCmdFromArguments(otherArgs)));
+  .action(withGlobalOpts(Contract.call));
 
 //
 // ## Initialize `deploy` command
@@ -153,6 +153,6 @@ program
   .option('-T, --ttl [ttl]', 'Validity of the spend transaction in number of blocks (default forever)', TX_TTL)
   .option('-N, --nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
   .description('Deploy a contract on the chain')
-  .action((walletPath, args, ...otherArgs) => Contract.deploy(walletPath, args, getCmdFromArguments(otherArgs)));
+  .action(withGlobalOpts(Contract.deploy));
 
 export default program;

--- a/src/commands/contract.js
+++ b/src/commands/contract.js
@@ -20,12 +20,11 @@
 // We'll use `commander` for parsing options
 import { Argument, Option, Command } from 'commander';
 import { TX_TTL, MIN_GAS_PRICE } from '@aeternity/aepp-sdk';
-import { COMPILER_URL } from '../utils/constant';
 import { withGlobalOpts } from '../utils/cli';
 import CliError from '../utils/CliError';
 import * as Contract from '../actions/contract';
 import {
-  nodeOption, jsonOption, gasOption, feeOption,
+  nodeOption, compilerOption, jsonOption, gasOption, feeOption,
 } from '../arguments';
 
 const callArgs = new Argument('[args]', 'JSON-encoded arguments array of contract call')
@@ -50,7 +49,7 @@ const program = new Command().name('aecli contract');
 // ## Initialize `options`
 program
   .addOption(nodeOption)
-  .option('--compilerUrl [compilerUrl]', 'Compiler URL', COMPILER_URL)
+  .addOption(compilerOption)
   .option('-f --force', 'Ignore node version compatibility check')
   .addOption(jsonOption);
 

--- a/src/commands/contract.js
+++ b/src/commands/contract.js
@@ -20,7 +20,6 @@
 // We'll use `commander` for parsing options
 import { Argument, Option, Command } from 'commander';
 import { MIN_GAS_PRICE } from '@aeternity/aepp-sdk';
-import { withGlobalOpts } from '../utils/cli';
 import CliError from '../utils/CliError';
 import * as Contract from '../actions/contract';
 import {
@@ -54,8 +53,7 @@ const contractAciFilenameOption = new Option('--contractAci [contractAci]', 'Con
 
 const program = new Command().name('aecli contract');
 
-// ## Initialize `options`
-program
+const addCommonOptions = (p) => p
   .addOption(nodeOption)
   .addOption(compilerOption)
   .addOption(forceOption)
@@ -66,24 +64,24 @@ program
 // You can use this command to compile your `contract` to `bytecode`
 //
 // Example: `aecli contract compile ./mycontract.contract`
-program
+addCommonOptions(program
   .command('compile <file>')
   .description('Compile a contract')
-  .action(withGlobalOpts(Contract.compile));
+  .action(Contract.compile));
 
 // ## Initialize `encode-calldata` command
 //
 // You can use this command to prepare `callData`
 //
 // Example: `aecli contract encodeData ./mycontract.contract testFn 1 2`
-program
+addCommonOptions(program
   .command('encode-calldata <fn>')
   .addArgument(callArgs)
   .addOption(descriptorPathOption)
   .addOption(contractSourceFilenameOption)
   .addOption(contractAciFilenameOption)
   .description('Encode contract calldata')
-  .action(withGlobalOpts(Contract.encodeCalldata));
+  .action(Contract.encodeCalldata));
 
 // ## Initialize `decode-calldata` command
 //
@@ -91,13 +89,13 @@ program
 //
 // Example bytecode: `aecli contract decodeCallData cb_asdasdasd... --code cb_asdasdasdasd....`
 // Example source code: `aecli contract decodeCallData cb_asdasdasd... --sourcePath ./contractSource --fn someFunction`
-program
+addCommonOptions(program
   .command('decode-call-result <fn> <data>')
   .addOption(descriptorPathOption)
   .addOption(contractSourceFilenameOption)
   .addOption(contractAciFilenameOption)
   .description('Decode contract calldata')
-  .action(withGlobalOpts(Contract.decodeCallResult));
+  .action(Contract.decodeCallResult));
 
 // ## Initialize `call` command
 //
@@ -113,7 +111,7 @@ program
 //    `aecli contract call ./myWalletFile --password testpass sumFunc '[1, 2]' --contractAddress ct_1dsf35423fdsg345g4wsdf35ty54234235 --callStatic` --> Static call using contract address
 // You can preset gas, nonce and ttl for that call. If not set use default.
 // Example: `aecli contract call ./myWalletFile --password testpass sumFunc '[1, 2]' --descrPath ./contractDescriptorFile.json --gas 2222222 --nonce 4 --ttl 1243`
-program
+addCommonOptions(program
   .command('call')
   .argument('<fn>', 'Name of contract entrypoint to call')
   .addArgument(callArgs)
@@ -132,7 +130,7 @@ program
   .addOption(ttlOption)
   .option('-N, --nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
   .description('Execute a function of the contract')
-  .action(withGlobalOpts(Contract.call));
+  .action(Contract.call));
 
 //
 // ## Initialize `deploy` command
@@ -144,7 +142,7 @@ program
 // You can preset gas and initState for deploy
 //
 // Example: `aecli contract deploy ./myWalletFile --password tstpass ./contractSourceCodeFile --gas 2222222`
-program
+addCommonOptions(program
   .command('deploy <wallet_path>')
   .addArgument(callArgs)
   .addOption(descriptorPathOption)
@@ -160,6 +158,6 @@ program
   .addOption(ttlOption)
   .option('-N, --nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
   .description('Deploy a contract on the chain')
-  .action(withGlobalOpts(Contract.deploy));
+  .action(Contract.deploy));
 
 export default program;

--- a/src/commands/contract.js
+++ b/src/commands/contract.js
@@ -24,7 +24,7 @@ import { withGlobalOpts } from '../utils/cli';
 import CliError from '../utils/CliError';
 import * as Contract from '../actions/contract';
 import {
-  nodeOption, compilerOption, jsonOption, gasOption, feeOption,
+  nodeOption, compilerOption, jsonOption, gasOption, feeOption, forceOption,
 } from '../arguments';
 
 const callArgs = new Argument('[args]', 'JSON-encoded arguments array of contract call')
@@ -50,7 +50,7 @@ const program = new Command().name('aecli contract');
 program
   .addOption(nodeOption)
   .addOption(compilerOption)
-  .option('-f --force', 'Ignore node version compatibility check')
+  .addOption(forceOption)
   .addOption(jsonOption);
 
 // ## Initialize `compile` command

--- a/src/commands/contract.js
+++ b/src/commands/contract.js
@@ -32,6 +32,7 @@ import {
   forceOption,
   passwordOption,
   ttlOption,
+  networkIdOption,
 } from '../arguments';
 
 const callArgs = new Argument('[args]', 'JSON-encoded arguments array of contract call')
@@ -122,7 +123,7 @@ program
   .addOption(contractSourceFilenameOption)
   .addOption(contractAciFilenameOption)
   .option('-W, --no-waitMined', 'Force waiting until transaction will be mined')
-  .option('--networkId [networkId]', 'Network id (default: ae_mainnet)')
+  .addOption(networkIdOption)
   .addOption(passwordOption)
   .addOption(gasOption)
   .option('-s --callStatic', 'Call static')
@@ -150,7 +151,7 @@ program
   .addOption(contractSourceFilenameOption)
   .option('--contractBytecode [contractBytecode]', 'Contract bytecode file name')
   .addOption(contractAciFilenameOption)
-  .option('--networkId [networkId]', 'Network id (default: ae_mainnet)')
+  .addOption(networkIdOption)
   .option('-W, --no-waitMined', 'Force waiting until transaction will be mined')
   .addOption(passwordOption)
   .addOption(gasOption)

--- a/src/commands/crypto.js
+++ b/src/commands/crypto.js
@@ -22,7 +22,7 @@ import {
 } from '@aeternity/aepp-sdk';
 import { print } from '../utils/print';
 import CliError from '../utils/CliError';
-import { passwordOption } from '../arguments';
+import { networkIdOption, passwordOption } from '../arguments';
 
 const program = new Command().name('aecli crypto');
 
@@ -40,7 +40,7 @@ program
   .command('sign <tx> [privkey]')
   .addOption(passwordOption)
   .option('-f, --file [file]', 'private key file')
-  .option('--networkId [networkId]', 'Network id', 'ae_mainnet')
+  .addOption(networkIdOption.default('ae_mainnet'))
   // ## Transaction Signing
   //
   // This function shows how to use a compliant private key to sign an æternity

--- a/src/commands/crypto.js
+++ b/src/commands/crypto.js
@@ -22,6 +22,7 @@ import {
 } from '@aeternity/aepp-sdk';
 import { print } from '../utils/print';
 import CliError from '../utils/CliError';
+import { passwordOption } from '../arguments';
 
 const program = new Command().name('aecli crypto');
 
@@ -37,7 +38,7 @@ program
 
 program
   .command('sign <tx> [privkey]')
-  .option('-p, --password [password]', 'password of the private key')
+  .addOption(passwordOption)
   .option('-f, --file [file]', 'private key file')
   .option('--networkId [networkId]', 'Network id', 'ae_mainnet')
   // ## Transaction Signing

--- a/src/commands/inspect.js
+++ b/src/commands/inspect.js
@@ -20,14 +20,14 @@
 // We'll use `commander` for parsing options
 import { Command } from 'commander';
 import inspect from '../actions/inspect';
-import { nodeOption, jsonOption } from '../arguments';
+import { nodeOption, jsonOption, forceOption } from '../arguments';
 
 const program = new Command().name('aecli inspect');
 
 // ## Initialize `options`
 program
   .addOption(nodeOption)
-  .option('-f --force', 'Ignore node version compatibility check')
+  .addOption(forceOption)
   .addOption(jsonOption);
 
 // ## Initialize `inspect` command

--- a/src/commands/inspect.js
+++ b/src/commands/inspect.js
@@ -25,7 +25,7 @@ import { nodeOption, jsonOption, forceOption } from '../arguments';
 const program = new Command().name('aecli inspect');
 
 // ## Initialize `options`
-program
+const addCommonOptions = (p) => p
   .addOption(nodeOption)
   .addOption(forceOption)
   .addOption(jsonOption);
@@ -45,9 +45,9 @@ program
 // Example: `aecli inspect 1234` --> get info about `block` by block `height`
 //
 // Example: `aecli inspect th_asfwegfj34234t34t` --> get info about `transaction` by transaction `hash`
-program
+addCommonOptions(program
   .arguments('<hash>')
   .description('Hash or Name to inspect (eg: ak_..., mk_..., name.chain)')
-  .action((hash, cmd) => inspect(hash, cmd));
+  .action(inspect));
 
 export default program;

--- a/src/commands/main.js
+++ b/src/commands/main.js
@@ -19,7 +19,11 @@
  */
 // We'll use `commander` for parsing options
 import { Command } from 'commander';
-import { NODE_URL, COMPILER_URL } from '../utils/constant';
+import prompts from 'prompts';
+import { Node, Compiler } from '@aeternity/aepp-sdk';
+import { compilerOption, nodeOption } from '../arguments';
+import { addToConfig } from '../utils/config';
+import CliError from '../utils/CliError';
 
 const program = new Command();
 
@@ -37,17 +41,109 @@ const EXECUTABLE_CMD = [
 // You get get CLI version by exec `aecli version`
 program.version(process.env.npm_package_version);
 
-// ## Initialize `config` command
-program
-  .command('config')
-  .description('Print the sdk default configuration')
-  .action(() => {
-    // TODO: show these values https://github.com/aeternity/aepp-cli-js/issues/174
-    console.log('NODE_URL', NODE_URL);
-    console.log('COMPILER_URL', COMPILER_URL);
-  });
-
 // ## Initialize `child` command's
 EXECUTABLE_CMD.forEach(({ name, desc }) => program.command(name, desc));
+
+async function getNodeDescription(url) {
+  // TODO: remove after fixing https://github.com/aeternity/aepp-sdk-js/issues/1673
+  const omitUncaughtExceptions = () => {};
+  process.on('uncaughtException', omitUncaughtExceptions);
+  const nodeInfo = await (new Node(url)).getNodeInfo().catch(() => {});
+  process.off('uncaughtException', omitUncaughtExceptions);
+  return nodeInfo
+    ? `network id ${nodeInfo.nodeNetworkId}, version ${nodeInfo.version}`
+    : 'can\'t get node info';
+}
+
+async function getCompilerDescription(url) {
+  // TODO: remove after fixing https://github.com/aeternity/aepp-sdk-js/issues/1673
+  const omitUncaughtExceptions = () => {};
+  process.on('uncaughtException', omitUncaughtExceptions);
+  const { apiVersion } = await (new Compiler(url)).aPIVersion().catch(() => ({}));
+  process.off('uncaughtException', omitUncaughtExceptions);
+  return apiVersion ? `version ${apiVersion}` : 'can\'t get compiler version';
+}
+
+program
+  .command('config')
+  .description('Print the current sdk configuration')
+  .addOption(nodeOption)
+  .addOption(compilerOption)
+  .action(async ({ url, compilerUrl }) => {
+    console.log('Node', url, await getNodeDescription(url));
+    console.log('Compiler', compilerUrl, await getCompilerDescription(compilerUrl));
+  });
+
+async function askUrl(entity, choices, getDescription, _url) {
+  let url = _url;
+  if (url == null) {
+    const getChoices = async (withDescriptions) => [
+      ...await Promise.all(choices.map(async (choice) => ({
+        title: choice.name,
+        value: choice.url,
+        description: withDescriptions ? await getDescription(choice.url) : 'version loading...',
+      }))),
+      {
+        title: 'Enter URL',
+        value: 'custom-url',
+      },
+    ];
+
+    let loadingDescription = false;
+    url = (await prompts({
+      type: 'select',
+      name: 'url',
+      message: `Select a ${entity} to use in other commands`,
+      choices: await getChoices(false),
+      async onRender() {
+        if (loadingDescription) return;
+        loadingDescription = true;
+        this.choices = await getChoices(true);
+        this.render();
+      },
+    })).url;
+
+    if (url === 'custom-url') {
+      url = (await prompts({
+        type: 'text',
+        name: 'url',
+        message: `Enter a ${entity} url to use in other commands`,
+      })).url;
+    }
+
+    if (url == null) process.exit(0);
+  }
+  try {
+    return (new URL(url)).toString();
+  } catch (error) {
+    throw new CliError(error.message);
+  }
+}
+
+program
+  .command('select-node')
+  .argument('[nodeUrl]', 'Node URL')
+  .description('Specify node to use in other commands')
+  .action(async (url) => {
+    const nodes = [
+      { name: 'Mainnet', url: 'https://mainnet.aeternity.io/' },
+      { name: 'Testnet', url: 'https://testnet.aeternity.io/' },
+    ];
+    await addToConfig({ url: await askUrl('node', nodes, getNodeDescription, url) });
+  });
+
+program
+  .command('select-compiler')
+  .argument('[compilerUrl]', 'Compiler URL')
+  .description('Specify compiler to use in other commands')
+  .action(async (url) => {
+    const compilers = [
+      { name: 'Stable', url: 'https://compiler.aeternity.io/' },
+      { name: 'Latest', url: 'https://latest.compiler.aeternity.io/' },
+    ];
+    await addToConfig({
+      compilerUrl: await askUrl('compiler', compilers, getCompilerDescription, url),
+    });
+  });
 
 export default program;

--- a/src/commands/name.js
+++ b/src/commands/name.js
@@ -24,7 +24,9 @@ import { Command } from 'commander';
 import { TX_TTL, NAME_TTL, CLIENT_TTL } from '@aeternity/aepp-sdk';
 import { withGlobalOpts } from '../utils/cli';
 import * as AENS from '../actions/aens';
-import { nodeOption, jsonOption, feeOption } from '../arguments';
+import {
+  nodeOption, jsonOption, feeOption, forceOption,
+} from '../arguments';
 
 const program = new Command().name('aecli name');
 
@@ -36,7 +38,7 @@ program
   .option('--nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
   .option('-P, --password [password]', 'Wallet Password')
   .option('--networkId [networkId]', 'Network id (default: ae_mainnet)')
-  .option('-f --force', 'Ignore node version compatibility check')
+  .addOption(forceOption)
   .addOption(jsonOption);
 
 // ## Initialize `claim` command

--- a/src/commands/name.js
+++ b/src/commands/name.js
@@ -25,7 +25,7 @@ import { NAME_TTL, CLIENT_TTL } from '@aeternity/aepp-sdk';
 import { withGlobalOpts } from '../utils/cli';
 import * as AENS from '../actions/aens';
 import {
-  nodeOption, jsonOption, feeOption, forceOption, passwordOption, ttlOption,
+  nodeOption, jsonOption, feeOption, forceOption, passwordOption, ttlOption, networkIdOption,
 } from '../arguments';
 
 const program = new Command().name('aecli name');
@@ -37,7 +37,7 @@ program
   .addOption(feeOption)
   .option('--nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
   .addOption(passwordOption)
-  .option('--networkId [networkId]', 'Network id (default: ae_mainnet)')
+  .addOption(networkIdOption)
   .addOption(forceOption)
   .addOption(jsonOption);
 

--- a/src/commands/name.js
+++ b/src/commands/name.js
@@ -22,7 +22,6 @@
 // Also we need `esm` package to handle `ES imports`
 import { Command } from 'commander';
 import { NAME_TTL, CLIENT_TTL } from '@aeternity/aepp-sdk';
-import { withGlobalOpts } from '../utils/cli';
 import * as AENS from '../actions/aens';
 import {
   nodeOption, jsonOption, feeOption, forceOption, passwordOption, ttlOption, networkIdOption,
@@ -31,7 +30,7 @@ import {
 const program = new Command().name('aecli name');
 
 // ## Initialize `options`
-program
+const addCommonOptions = (p) => p
   .addOption(nodeOption)
   .addOption(ttlOption)
   .addOption(feeOption)
@@ -50,14 +49,14 @@ program
 // This command send `pre-claim` transaction, wait until one block was mined, after that sent `claim` and `update` transaction's
 //
 // You can use `--nameTtl` and `--ttl` to pre-set transaction and name `time to leave`
-program
+addCommonOptions(program
   .command('full-claim <wallet_path> <name>')
   .option('-M, --no-waitMined', 'Do not wait until transaction will be mined')
   .option('--nameFee [nameFee]', 'Amount of coins to pay for name')
   .option('--nameTtl [nameTtl]', 'Validity of name.', NAME_TTL)
   .option('--clientTtl [clientTtl]', 'Client ttl.', CLIENT_TTL)
   .description('Claim a domain name')
-  .action(withGlobalOpts(AENS.fullClaim));
+  .action(AENS.fullClaim));
 
 // ## Initialize `pre-claim` command
 //
@@ -69,11 +68,11 @@ program
 // And wait until it will be mined. You can force waiting by using `--waitMined false` option. Default: true
 //
 // You can use `--ttl` to pre-set transaction `time to leave`
-program
+addCommonOptions(program
   .command('pre-claim <wallet_path> <name>')
   .option('-M, --no-waitMined', 'Do not wait until transaction will be mined')
   .description('Pre-Claim a domain name')
-  .action(withGlobalOpts(AENS.preClaim));
+  .action(AENS.preClaim));
 
 // ## Initialize `claim` command
 //
@@ -84,12 +83,12 @@ program
 // This command send `pre-claim` transaction, wait until one block was mined, after that sent `claim` and `update` transaction's
 //
 // You can use `--nameTtl` and `--ttl` to pre-set transaction and name `time to leave`
-program
+addCommonOptions(program
   .command('claim <wallet_path> <name> <salt>')
   .option('-M, --no-waitMined', 'Do not wait until transaction will be mined')
   .option('--nameFee [nameFee]', 'Amount of coins to pay for name')
   .description('Claim a domain name')
-  .action(withGlobalOpts(AENS.claim));
+  .action(AENS.claim));
 
 // ## Initialize `claim` command
 //
@@ -100,68 +99,68 @@ program
 // This command send `pre-claim` transaction, wait until one block was mined, after that sent `claim` and `update` transaction's
 //
 // You can use `--nameTtl` and `--ttl` to pre-set transaction and name `time to leave`
-program
+addCommonOptions(program
   .command('bid <wallet_path> <name> <nameFee>')
   .option('-M, --no-waitMined', 'Do not wait until transaction will be mined')
   .description('Bid on name')
-  .action(withGlobalOpts(AENS.nameBid));
+  .action(AENS.nameBid));
 
 // ## Initialize `update` command
 //
 // You can use this command to `update` pointer of AENS name.
 //
 // Example: `aecli name update ./myWalletKeyFile --password testpass testname.chain ak_qwe23dffasfgdesag323`
-program
+addCommonOptions(program
   .command('update <wallet_path> <name> [addresses...]')
   .option('-M, --no-waitMined', 'Do not wait until transaction will be mined')
   .option('--extendPointers', 'Extend pointers', false)
   .option('--nameTtl [nameTtl]', 'Validity of name.', NAME_TTL)
   .option('--clientTtl [clientTtl]', 'Client ttl.', CLIENT_TTL)
   .description('Update a name pointer')
-  .action(withGlobalOpts(AENS.updateName));
+  .action(AENS.updateName));
 
 // ## Initialize `extend` command
 //
 // You can use this command to `extend` ttl of AENS name.
 //
 // Example: `aecli name extend ./myWalletKeyFile --password testpass testname.chain 100`
-program
+addCommonOptions(program
   .command('extend <wallet_path> <name> <nameTtl')
   .option('-M, --no-waitMined', 'Do not wait until transaction will be mined')
   .option('--clientTtl [clientTtl]', 'Client ttl.', CLIENT_TTL)
   .description('Extend name ttl')
-  .action(withGlobalOpts(AENS.extendName));
+  .action(AENS.extendName));
 
 // ## Initialize `revoke` command
 //
 // You can use this command to `destroy` AENS name.
 //
 // Example: `aecli name revoke ./myWalletKeyFile --password testpass testname.chain`
-program
+addCommonOptions(program
   .command('revoke  <wallet_path> <name>')
   .option('-M, --no-waitMined', 'Do not wait until transaction will be mined')
   .description('Revoke a domain name')
-  .action(withGlobalOpts(AENS.revokeName));
+  .action(AENS.revokeName));
 
 // ## Initialize `transfer` command
 //
 // You can use this command to `transfer` AENS name to another account.
 //
 // Example: `aecli name transfer ./myWalletKeyFile --password testpass testname.chain ak_qqwemjgflewgkj349gjdslksd`
-program
+addCommonOptions(program
   .command('transfer <wallet_path> <name> <address>')
   .option('-M, --no-waitMined', 'Do not wait until transaction will be mined')
   .description('Transfer a name to another account')
-  .action(withGlobalOpts(AENS.transferName));
+  .action(AENS.transferName));
 
 // ## Initialize `lookup` command
 //
 // You can use this command to `update` pointer of AENS name.
 //
 // Example: `aecli lookup name.chain`
-program
+addCommonOptions(program
   .command('lookup <name>')
   .description('Look up name')
-  .action(withGlobalOpts(AENS.lookUp));
+  .action(AENS.lookUp));
 
 export default program;

--- a/src/commands/name.js
+++ b/src/commands/name.js
@@ -21,11 +21,11 @@
 //
 // Also we need `esm` package to handle `ES imports`
 import { Command } from 'commander';
-import { TX_TTL, NAME_TTL, CLIENT_TTL } from '@aeternity/aepp-sdk';
+import { NAME_TTL, CLIENT_TTL } from '@aeternity/aepp-sdk';
 import { withGlobalOpts } from '../utils/cli';
 import * as AENS from '../actions/aens';
 import {
-  nodeOption, jsonOption, feeOption, forceOption, passwordOption,
+  nodeOption, jsonOption, feeOption, forceOption, passwordOption, ttlOption,
 } from '../arguments';
 
 const program = new Command().name('aecli name');
@@ -33,7 +33,7 @@ const program = new Command().name('aecli name');
 // ## Initialize `options`
 program
   .addOption(nodeOption)
-  .option('--ttl [ttl]', 'Override the ttl that the transaction is going to be sent with', TX_TTL)
+  .addOption(ttlOption)
   .addOption(feeOption)
   .option('--nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
   .addOption(passwordOption)

--- a/src/commands/name.js
+++ b/src/commands/name.js
@@ -25,7 +25,7 @@ import { TX_TTL, NAME_TTL, CLIENT_TTL } from '@aeternity/aepp-sdk';
 import { withGlobalOpts } from '../utils/cli';
 import * as AENS from '../actions/aens';
 import {
-  nodeOption, jsonOption, feeOption, forceOption,
+  nodeOption, jsonOption, feeOption, forceOption, passwordOption,
 } from '../arguments';
 
 const program = new Command().name('aecli name');
@@ -36,7 +36,7 @@ program
   .option('--ttl [ttl]', 'Override the ttl that the transaction is going to be sent with', TX_TTL)
   .addOption(feeOption)
   .option('--nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
-  .option('-P, --password [password]', 'Wallet Password')
+  .addOption(passwordOption)
   .option('--networkId [networkId]', 'Network id (default: ae_mainnet)')
   .addOption(forceOption)
   .addOption(jsonOption);

--- a/src/commands/name.js
+++ b/src/commands/name.js
@@ -22,7 +22,7 @@
 // Also we need `esm` package to handle `ES imports`
 import { Command } from 'commander';
 import { TX_TTL, NAME_TTL, CLIENT_TTL } from '@aeternity/aepp-sdk';
-import { getCmdFromArguments } from '../utils/cli';
+import { withGlobalOpts } from '../utils/cli';
 import * as AENS from '../actions/aens';
 import { nodeOption, jsonOption, feeOption } from '../arguments';
 
@@ -55,7 +55,7 @@ program
   .option('--nameTtl [nameTtl]', 'Validity of name.', NAME_TTL)
   .option('--clientTtl [clientTtl]', 'Client ttl.', CLIENT_TTL)
   .description('Claim a domain name')
-  .action((walletPath, name, ...args) => AENS.fullClaim(walletPath, name, getCmdFromArguments(args)));
+  .action(withGlobalOpts(AENS.fullClaim));
 
 // ## Initialize `pre-claim` command
 //
@@ -71,7 +71,7 @@ program
   .command('pre-claim <wallet_path> <name>')
   .option('-M, --no-waitMined', 'Do not wait until transaction will be mined')
   .description('Pre-Claim a domain name')
-  .action((walletPath, name, ...args) => AENS.preClaim(walletPath, name, getCmdFromArguments(args)));
+  .action(withGlobalOpts(AENS.preClaim));
 
 // ## Initialize `claim` command
 //
@@ -87,7 +87,7 @@ program
   .option('-M, --no-waitMined', 'Do not wait until transaction will be mined')
   .option('--nameFee [nameFee]', 'Amount of coins to pay for name')
   .description('Claim a domain name')
-  .action((walletPath, name, salt, ...args) => AENS.claim(walletPath, name, salt, getCmdFromArguments(args)));
+  .action(withGlobalOpts(AENS.claim));
 
 // ## Initialize `claim` command
 //
@@ -102,7 +102,7 @@ program
   .command('bid <wallet_path> <name> <nameFee>')
   .option('-M, --no-waitMined', 'Do not wait until transaction will be mined')
   .description('Bid on name')
-  .action((walletPath, name, nameFee, ...args) => AENS.nameBid(walletPath, name, nameFee, getCmdFromArguments(args)));
+  .action(withGlobalOpts(AENS.nameBid));
 
 // ## Initialize `update` command
 //
@@ -116,7 +116,7 @@ program
   .option('--nameTtl [nameTtl]', 'Validity of name.', NAME_TTL)
   .option('--clientTtl [clientTtl]', 'Client ttl.', CLIENT_TTL)
   .description('Update a name pointer')
-  .action((walletPath, name, addresses, ...args) => AENS.updateName(walletPath, name, addresses, getCmdFromArguments(args)));
+  .action(withGlobalOpts(AENS.updateName));
 
 // ## Initialize `extend` command
 //
@@ -128,7 +128,7 @@ program
   .option('-M, --no-waitMined', 'Do not wait until transaction will be mined')
   .option('--clientTtl [clientTtl]', 'Client ttl.', CLIENT_TTL)
   .description('Extend name ttl')
-  .action((walletPath, name, nameTtl, ...args) => AENS.extendName(walletPath, name, nameTtl, getCmdFromArguments(args)));
+  .action(withGlobalOpts(AENS.extendName));
 
 // ## Initialize `revoke` command
 //
@@ -139,7 +139,7 @@ program
   .command('revoke  <wallet_path> <name>')
   .option('-M, --no-waitMined', 'Do not wait until transaction will be mined')
   .description('Revoke a domain name')
-  .action((walletPath, name, ...args) => AENS.revokeName(walletPath, name, getCmdFromArguments(args)));
+  .action(withGlobalOpts(AENS.revokeName));
 
 // ## Initialize `transfer` command
 //
@@ -150,7 +150,7 @@ program
   .command('transfer <wallet_path> <name> <address>')
   .option('-M, --no-waitMined', 'Do not wait until transaction will be mined')
   .description('Transfer a name to another account')
-  .action((walletPath, name, address, ...args) => AENS.transferName(walletPath, name, address, getCmdFromArguments(args)));
+  .action(withGlobalOpts(AENS.transferName));
 
 // ## Initialize `lookup` command
 //
@@ -160,6 +160,6 @@ program
 program
   .command('lookup <name>')
   .description('Look up name')
-  .action((name, ...args) => AENS.lookUp(name, getCmdFromArguments(args)));
+  .action(withGlobalOpts(AENS.lookUp));
 
 export default program;

--- a/src/commands/oracle.js
+++ b/src/commands/oracle.js
@@ -26,7 +26,7 @@ import { RESPONSE_TTL } from '../utils/constant';
 import { withGlobalOpts } from '../utils/cli';
 import * as Oracle from '../actions/oracle';
 import {
-  nodeOption, jsonOption, feeOption, forceOption,
+  nodeOption, jsonOption, feeOption, forceOption, passwordOption,
 } from '../arguments';
 
 const program = new Command().name('aecli oracle');
@@ -37,7 +37,7 @@ program
   .option('--ttl [ttl]', 'Override the ttl that the transaction is going to be sent with', TX_TTL)
   .addOption(feeOption)
   .option('--nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
-  .option('-P, --password [password]', 'Wallet Password')
+  .addOption(passwordOption)
   .option('--networkId [networkId]', 'Network id (default: ae_mainnet)')
   .addOption(forceOption)
   .addOption(jsonOption);

--- a/src/commands/oracle.js
+++ b/src/commands/oracle.js
@@ -21,7 +21,6 @@
 import { Command } from 'commander';
 import { ORACLE_TTL, QUERY_FEE, QUERY_TTL } from '@aeternity/aepp-sdk';
 import { RESPONSE_TTL } from '../utils/constant';
-import { withGlobalOpts } from '../utils/cli';
 import * as Oracle from '../actions/oracle';
 import {
   nodeOption, jsonOption, feeOption, forceOption, passwordOption, ttlOption, networkIdOption,
@@ -30,7 +29,7 @@ import {
 const program = new Command().name('aecli oracle');
 
 // ## Initialize `options`
-program
+const addCommonOptions = (p) => p
   .addOption(nodeOption)
   .addOption(ttlOption)
   .addOption(feeOption)
@@ -49,13 +48,13 @@ program
 // And wait until it will be mined. You can force waiting by using `--waitMined false` option. Default: true
 //
 // You can use `--ttl` to pre-set transaction `time to leave`
-program
+addCommonOptions(program
   .command('create <wallet_path> <queryFormat> <responseFormat>')
   .option('-M, --no-waitMined', 'Do not wait until transaction will be mined')
   .option('--oracleTtl [oracleTtl]', 'Relative Oracle time to leave', ORACLE_TTL)
   .option('--queryFee [queryFee]', 'Oracle query fee', QUERY_FEE)
   .description('Register Oracle')
-  .action(withGlobalOpts(Oracle.createOracle));
+  .action(Oracle.createOracle));
 
 // ## Initialize `extend oracle` command
 //
@@ -66,11 +65,11 @@ program
 // And wait until it will be mined. You can force waiting by using `--waitMined false` option. Default: true
 //
 // You can use `--ttl` to pre-set transaction `time to leave`
-program
+addCommonOptions(program
   .command('extend <wallet_path> <oracleId> <oracleTtl>')
   .option('-M, --no-waitMined', 'Do not wait until transaction will be mined')
   .description('Extend Oracle')
-  .action(withGlobalOpts(Oracle.extendOracle));
+  .action(Oracle.extendOracle));
 
 // ## Initialize `create oracle query` command
 //
@@ -81,14 +80,14 @@ program
 // And wait until it will be mined. You can force waiting by using `--waitMined false` option. Default: true
 //
 // You can use `--ttl` to pre-set transaction `time to leave`
-program
+addCommonOptions(program
   .command('create-query <wallet_path> <oracleId> <query>')
   .option('-M, --no-waitMined', 'Do not wait until transaction will be mined')
   .option('--responseTtl [responseTtl]', 'Query response time to leave', RESPONSE_TTL)
   .option('--queryTtl [queryTtl]', 'Query time to leave', QUERY_TTL)
   .option('--queryFee [queryFee]', 'Oracle query fee', QUERY_FEE)
   .description('Create Oracle query')
-  .action(withGlobalOpts(Oracle.createOracleQuery));
+  .action(Oracle.createOracleQuery));
 
 // ## Initialize `respond query` command
 //
@@ -99,12 +98,12 @@ program
 // And wait until it will be mined. You can force waiting by using `--waitMined false` option. Default: true
 //
 // You can use `--ttl` to pre-set transaction `time to leave`
-program
+addCommonOptions(program
   .command('respond-query <wallet_path> <oracleId> <queryId> <response>')
   .option('-M, --no-waitMined', 'Do not wait until transaction will be mined')
   .option('--responseTtl [responseTtl]', 'Query response time to leave', RESPONSE_TTL)
   .description('Respond to  Oracle Query')
-  .action(withGlobalOpts(Oracle.respondToQuery));
+  .action(Oracle.respondToQuery));
 
 // ## Initialize `get oracle` command
 //
@@ -115,9 +114,9 @@ program
 // And wait until it will be mined. You can force waiting by using `--waitMined false` option. Default: true
 //
 // You can use `--ttl` to pre-set transaction `time to leave`
-program
+addCommonOptions(program
   .command('get <oracleId>')
   .description('Get Oracle')
-  .action(withGlobalOpts(Oracle.queryOracle));
+  .action(Oracle.queryOracle));
 
 export default program;

--- a/src/commands/oracle.js
+++ b/src/commands/oracle.js
@@ -23,7 +23,7 @@ import {
   TX_TTL, ORACLE_TTL, QUERY_FEE, QUERY_TTL,
 } from '@aeternity/aepp-sdk';
 import { RESPONSE_TTL } from '../utils/constant';
-import { getCmdFromArguments } from '../utils/cli';
+import { withGlobalOpts } from '../utils/cli';
 import * as Oracle from '../actions/oracle';
 import { nodeOption, jsonOption, feeOption } from '../arguments';
 
@@ -55,7 +55,7 @@ program
   .option('--oracleTtl [oracleTtl]', 'Relative Oracle time to leave', ORACLE_TTL)
   .option('--queryFee [queryFee]', 'Oracle query fee', QUERY_FEE)
   .description('Register Oracle')
-  .action((walletPath, queryFormat, responseFormat, ...args) => Oracle.createOracle(walletPath, queryFormat, responseFormat, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Oracle.createOracle));
 
 // ## Initialize `extend oracle` command
 //
@@ -70,7 +70,7 @@ program
   .command('extend <wallet_path> <oracleId> <oracleTtl>')
   .option('-M, --no-waitMined', 'Do not wait until transaction will be mined')
   .description('Extend Oracle')
-  .action((walletPath, oracleId, oracleTtl, ...args) => Oracle.extendOracle(walletPath, oracleId, oracleTtl, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Oracle.extendOracle));
 
 // ## Initialize `create oracle query` command
 //
@@ -88,7 +88,7 @@ program
   .option('--queryTtl [queryTtl]', 'Query time to leave', QUERY_TTL)
   .option('--queryFee [queryFee]', 'Oracle query fee', QUERY_FEE)
   .description('Create Oracle query')
-  .action((walletPath, oracleId, query, ...args) => Oracle.createOracleQuery(walletPath, oracleId, query, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Oracle.createOracleQuery));
 
 // ## Initialize `respond query` command
 //
@@ -104,7 +104,7 @@ program
   .option('-M, --no-waitMined', 'Do not wait until transaction will be mined')
   .option('--responseTtl [responseTtl]', 'Query response time to leave', RESPONSE_TTL)
   .description('Respond to  Oracle Query')
-  .action((walletPath, oracleId, queryId, response, ...args) => Oracle.respondToQuery(walletPath, oracleId, queryId, response, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Oracle.respondToQuery));
 
 // ## Initialize `get oracle` command
 //
@@ -118,6 +118,6 @@ program
 program
   .command('get <oracleId>')
   .description('Get Oracle')
-  .action((oracleId, ...args) => Oracle.queryOracle(oracleId, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Oracle.queryOracle));
 
 export default program;

--- a/src/commands/oracle.js
+++ b/src/commands/oracle.js
@@ -24,7 +24,7 @@ import { RESPONSE_TTL } from '../utils/constant';
 import { withGlobalOpts } from '../utils/cli';
 import * as Oracle from '../actions/oracle';
 import {
-  nodeOption, jsonOption, feeOption, forceOption, passwordOption, ttlOption,
+  nodeOption, jsonOption, feeOption, forceOption, passwordOption, ttlOption, networkIdOption,
 } from '../arguments';
 
 const program = new Command().name('aecli oracle');
@@ -36,7 +36,7 @@ program
   .addOption(feeOption)
   .option('--nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
   .addOption(passwordOption)
-  .option('--networkId [networkId]', 'Network id (default: ae_mainnet)')
+  .addOption(networkIdOption)
   .addOption(forceOption)
   .addOption(jsonOption);
 

--- a/src/commands/oracle.js
+++ b/src/commands/oracle.js
@@ -19,14 +19,12 @@
  */
 // We'll use `commander` for parsing options
 import { Command } from 'commander';
-import {
-  TX_TTL, ORACLE_TTL, QUERY_FEE, QUERY_TTL,
-} from '@aeternity/aepp-sdk';
+import { ORACLE_TTL, QUERY_FEE, QUERY_TTL } from '@aeternity/aepp-sdk';
 import { RESPONSE_TTL } from '../utils/constant';
 import { withGlobalOpts } from '../utils/cli';
 import * as Oracle from '../actions/oracle';
 import {
-  nodeOption, jsonOption, feeOption, forceOption, passwordOption,
+  nodeOption, jsonOption, feeOption, forceOption, passwordOption, ttlOption,
 } from '../arguments';
 
 const program = new Command().name('aecli oracle');
@@ -34,7 +32,7 @@ const program = new Command().name('aecli oracle');
 // ## Initialize `options`
 program
   .addOption(nodeOption)
-  .option('--ttl [ttl]', 'Override the ttl that the transaction is going to be sent with', TX_TTL)
+  .addOption(ttlOption)
   .addOption(feeOption)
   .option('--nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
   .addOption(passwordOption)

--- a/src/commands/oracle.js
+++ b/src/commands/oracle.js
@@ -25,7 +25,9 @@ import {
 import { RESPONSE_TTL } from '../utils/constant';
 import { withGlobalOpts } from '../utils/cli';
 import * as Oracle from '../actions/oracle';
-import { nodeOption, jsonOption, feeOption } from '../arguments';
+import {
+  nodeOption, jsonOption, feeOption, forceOption,
+} from '../arguments';
 
 const program = new Command().name('aecli oracle');
 
@@ -37,7 +39,7 @@ program
   .option('--nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
   .option('-P, --password [password]', 'Wallet Password')
   .option('--networkId [networkId]', 'Network id (default: ae_mainnet)')
-  .option('-f --force', 'Ignore node version compatibility check')
+  .addOption(forceOption)
   .addOption(jsonOption);
 
 // ## Initialize `create` command

--- a/src/commands/tx.js
+++ b/src/commands/tx.js
@@ -22,13 +22,13 @@
 // Also we need `esm` package to handle `ES imports`
 import { Command } from 'commander';
 import {
-  TX_TTL, NAME_TTL, CLIENT_TTL, MIN_GAS_PRICE, QUERY_FEE, ORACLE_TTL, QUERY_TTL,
+  NAME_TTL, CLIENT_TTL, MIN_GAS_PRICE, QUERY_FEE, ORACLE_TTL, QUERY_TTL,
 } from '@aeternity/aepp-sdk';
 import { RESPONSE_TTL } from '../utils/constant';
 import { withGlobalOpts } from '../utils/cli';
 import * as Transaction from '../actions/transaction';
 import {
-  nodeOption, jsonOption, gasOption, nonceArgument, feeOption, forceOption,
+  nodeOption, jsonOption, gasOption, nonceArgument, feeOption, forceOption, ttlOption,
 } from '../arguments';
 
 const program = new Command().name('aecli tx');
@@ -38,7 +38,7 @@ program
   .addOption(nodeOption)
 // .option('--nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
   .addOption(feeOption)
-  .option('--ttl [fee]', 'Override the ttl that the transaction is going to be sent with', TX_TTL)
+  .addOption(ttlOption)
   .addOption(forceOption)
   .addOption(jsonOption);
 
@@ -74,7 +74,7 @@ program
   .command('name-update <accountId> <nameId>')
   .addArgument(nonceArgument)
   .argument('[pointers...]')
-  .option('-T, --ttl [ttl]', 'Validity of the transaction in number of blocks (default forever)', TX_TTL)
+  .addOption(ttlOption)
   .addOption(feeOption)
   .option('--nameTtl [nameTtl]', 'Validity of name.', NAME_TTL)
   .option('--clientTtl [clientTtl]', 'Client ttl.', CLIENT_TTL)
@@ -89,7 +89,7 @@ program
 program
   .command('name-claim <accountId> <salt> <domain>')
   .addArgument(nonceArgument)
-  .option('-T, --ttl [ttl]', 'Validity of the transaction in number of blocks (default forever)', TX_TTL)
+  .addOption(ttlOption)
   .addOption(feeOption)
   .option('--nameFee [nameFee]', 'Name fee.')
   .description('Build name claim transaction.')
@@ -103,7 +103,7 @@ program
 program
   .command('name-transfer <accountId> <recipientId> <domain>')
   .addArgument(nonceArgument)
-  .option('-T, --ttl [ttl]', 'Validity of the transaction in number of blocks (default forever)', TX_TTL)
+  .addOption(ttlOption)
   .addOption(feeOption)
   .description('Build name tansfer transaction.')
   .action(withGlobalOpts(Transaction.nameTransfer));
@@ -116,7 +116,7 @@ program
 program
   .command('name-revoke <accountId> <domain>')
   .addArgument(nonceArgument)
-  .option('-T, --ttl [ttl]', 'Validity of the transaction in number of blocks (default forever)', TX_TTL)
+  .addOption(ttlOption)
   .addOption(feeOption)
   .description('Build name revoke transaction.')
   .action(withGlobalOpts(Transaction.nameRevoke));
@@ -129,7 +129,7 @@ program
 program
   .command('contract-deploy <ownerId> <contractBytecode> <initCallData>')
   .addArgument(nonceArgument)
-  .option('-T, --ttl [ttl]', 'Validity of the transaction in number of blocks (default forever)', TX_TTL)
+  .addOption(ttlOption)
   .addOption(feeOption)
   .addOption(gasOption)
   .option('-G --gasPrice [gas]', 'Amount of gas to deploy the contract', MIN_GAS_PRICE)
@@ -145,7 +145,7 @@ program
 program
   .command('contract-call <callerId> <contractId> <callData>')
   .addArgument(nonceArgument)
-  .option('-T, --ttl [ttl]', 'Validity of the transaction in number of blocks (default forever)', TX_TTL)
+  .addOption(ttlOption)
   .addOption(feeOption)
   .addOption(gasOption)
   .option('-G --gasPrice [gas]', 'Amount of gas to deploy the contract', MIN_GAS_PRICE)
@@ -161,7 +161,7 @@ program
 program
   .command('oracle-register <accountId> <queryFormat> <responseFormat>')
   .addArgument(nonceArgument)
-  .option('-T, --ttl [ttl]', 'Validity of the transaction in number of blocks (default forever)', TX_TTL)
+  .addOption(ttlOption)
   .addOption(feeOption)
   .option('--queryFee [queryFee]', 'Oracle Query fee.', QUERY_FEE)
   .option('--oracleTtl [oracleTtl]', 'Oracle Ttl.', ORACLE_TTL.value)
@@ -176,7 +176,7 @@ program
 program
   .command('oracle-post-query <accountId> <oracleId> <query>')
   .addArgument(nonceArgument)
-  .option('-T, --ttl [ttl]', 'Validity of the transaction in number of blocks (default forever)', TX_TTL)
+  .addOption(ttlOption)
   .addOption(feeOption)
   .option('--queryFee [queryFee]', 'Oracle Query fee.', QUERY_FEE)
   .option('--queryTtl [oracleTtl]', 'Oracle Ttl.', QUERY_TTL.value)
@@ -192,7 +192,7 @@ program
 program
   .command('oracle-extend <callerId> <oracleId> <oracleTtl>')
   .addArgument(nonceArgument)
-  .option('-T, --ttl [ttl]', 'Validity of the transaction in number of blocks (default forever)', TX_TTL)
+  .addOption(ttlOption)
   .addOption(feeOption)
   .description('Build oracle extend transaction.')
   .action(withGlobalOpts(Transaction.oracleExtend));
@@ -205,7 +205,7 @@ program
 program
   .command('oracle-respond <callerId> <oracleId> <queryId> <response>')
   .addArgument(nonceArgument)
-  .option('-T, --ttl [ttl]', 'Validity of the transaction in number of blocks (default forever)', TX_TTL)
+  .addOption(ttlOption)
   .addOption(feeOption)
   .option('--responseTtl [oracleTtl]', 'Oracle Ttl.', RESPONSE_TTL)
   .description('Build oracle extend transaction.')

--- a/src/commands/tx.js
+++ b/src/commands/tx.js
@@ -25,7 +25,6 @@ import {
   NAME_TTL, CLIENT_TTL, MIN_GAS_PRICE, QUERY_FEE, ORACLE_TTL, QUERY_TTL,
 } from '@aeternity/aepp-sdk';
 import { RESPONSE_TTL } from '../utils/constant';
-import { withGlobalOpts } from '../utils/cli';
 import * as Transaction from '../actions/transaction';
 import {
   nodeOption,
@@ -41,7 +40,7 @@ import {
 const program = new Command().name('aecli tx');
 
 // ## Initialize `options`
-program
+const addCommonOptions = (p) => p
   .addOption(nodeOption)
 // .option('--nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
   .addOption(feeOption)
@@ -54,30 +53,30 @@ program
 // You can use this command to build `spend` transaction
 //
 // Example: `aecli tx spend ak_2a1j2Mk9YSmC1gioUq4PWRm3bsv887MbuRVwyv4KaUGoR1eiKi ak_AgV756Vfo99juwzNVgnjP1gXX1op1QN3NXTxvkPnHJPUDE8NT 100`
-program
+addCommonOptions(program
   .command('spend <senderId> <recieverId> <amount>')
   .addArgument(nonceArgument)
   .option('--payload [payload]', 'Transaction payload.', '')
   .description('Build Spend Transaction')
-  .action(withGlobalOpts(Transaction.spend));
+  .action(Transaction.spend));
 
 // ## Initialize `name-preclaim` command
 //
 // You can use this command to build `preclaim` transaction
 //
 // Example: `aecli tx name-preclaim ak_2a1j2Mk9YSmC1gioUq4PWRm3bsv887MbuRVwyv4KaUGoR1eiKi testname.chain`
-program
+addCommonOptions(program
   .command('name-preclaim <accountId> <domain>')
   .addArgument(nonceArgument)
   .description('Build name preclaim transaction.')
-  .action(withGlobalOpts(Transaction.namePreClaim));
+  .action(Transaction.namePreClaim));
 
 // ## Initialize `name-update` command
 //
 // You can use this command to build `update` transaction
 //
 // Example: `aecli tx name-update ak_2a1j2Mk9YSmC1gioUq4PWRm3bsv887MbuRVwyv4KaUGoR1eiKi testname.chain`
-program
+addCommonOptions(program
   .command('name-update <accountId> <nameId>')
   .addArgument(nonceArgument)
   .argument('[pointers...]')
@@ -86,54 +85,54 @@ program
   .option('--nameTtl [nameTtl]', 'Validity of name.', NAME_TTL)
   .option('--clientTtl [clientTtl]', 'Client ttl.', CLIENT_TTL)
   .description('Build name update transaction.')
-  .action(withGlobalOpts(Transaction.nameUpdate));
+  .action(Transaction.nameUpdate));
 
 // ## Initialize `name-claim` command
 //
 // You can use this command to build `claim` transaction
 //
 // Example: `aecli tx name-claim ak_2a1j2Mk9YSmC1gioUq4PWRm3bsv887MbuRVwyv4KaUGoR1eiKi 12327389123 testname.chain`
-program
+addCommonOptions(program
   .command('name-claim <accountId> <salt> <domain>')
   .addArgument(nonceArgument)
   .addOption(ttlOption)
   .addOption(feeOption)
   .option('--nameFee [nameFee]', 'Name fee.')
   .description('Build name claim transaction.')
-  .action(withGlobalOpts(Transaction.nameClaim));
+  .action(Transaction.nameClaim));
 
 // ## Initialize `name-transfer` command
 //
 // You can use this command to build `tansfer` transaction
 //
 // Example: `aecli tx name-transfer ak_2a1j2Mk9YSmC1gioUq4PWRm3bsv887MbuRVwyv4KaUGoR1eiKi ak_2a1j2Mk9YSmC1gioUq4PWRm3bsv887MbuRVwyv4KaUGoR1eiKi testname.chain`
-program
+addCommonOptions(program
   .command('name-transfer <accountId> <recipientId> <domain>')
   .addArgument(nonceArgument)
   .addOption(ttlOption)
   .addOption(feeOption)
   .description('Build name tansfer transaction.')
-  .action(withGlobalOpts(Transaction.nameTransfer));
+  .action(Transaction.nameTransfer));
 
 // ## Initialize `name-revoke` command
 //
 // You can use this command to build `revoke` transaction
 //
 // Example: `aecli tx name-revoke ak_2a1j2Mk9YSmC1gioUq4PWRm3bsv887MbuRVwyv4KaUGoR1eiKi testname.chain`
-program
+addCommonOptions(program
   .command('name-revoke <accountId> <domain>')
   .addArgument(nonceArgument)
   .addOption(ttlOption)
   .addOption(feeOption)
   .description('Build name revoke transaction.')
-  .action(withGlobalOpts(Transaction.nameRevoke));
+  .action(Transaction.nameRevoke));
 
 // ## Initialize `contract-deploy` command
 //
 // You can use this command to build `contract create` transaction
 //
 // Example: `aecli tx contract-deploy ak_2a1j2Mk9YSmC1gioUq4PWRm3bsv887MbuRVwyv4KaUGoR1eiKi test.contract`
-program
+addCommonOptions(program
   .command('contract-deploy <ownerId> <contractBytecode> <initCallData>')
   .addArgument(nonceArgument)
   .addOption(ttlOption)
@@ -142,14 +141,14 @@ program
   .option('-G --gasPrice [gas]', 'Amount of gas to deploy the contract', MIN_GAS_PRICE)
   .option('--amount [amount]', 'Amount', 0)
   .description('Build contract create transaction.')
-  .action(withGlobalOpts(Transaction.contractDeploy));
+  .action(Transaction.contractDeploy));
 
 // ## Initialize `contract-call` command
 //
 // You can use this command to build `contract call` transaction
 //
 // Example: `aecli tx contract-call ak_2a1j2Mk9YSmC1gioUq4PWRm3bsv887MbuRVwyv4KaUGoR1eiKi ct_2134235423dsfsdfsdf sum int 1 2`
-program
+addCommonOptions(program
   .command('contract-call <callerId> <contractId> <callData>')
   .addArgument(nonceArgument)
   .addOption(ttlOption)
@@ -158,14 +157,14 @@ program
   .option('-G --gasPrice [gas]', 'Amount of gas to deploy the contract', MIN_GAS_PRICE)
   .option('--amount [amount]', 'Amount', 0)
   .description('Build contract create transaction.')
-  .action(withGlobalOpts(Transaction.contractCall));
+  .action(Transaction.contractCall));
 
 // ## Initialize `oracle-register` command
 //
 // You can use this command to build `oracle-register` transaction
 //
 // Example: `aecli tx oracle-register ak_2a1j2Mk9YSmC1gioUq4PWRm3bsv887MbuRVwyv4KaUGoR1eiKi  "{city: 'string'}" "{tmp: 'num'}"``
-program
+addCommonOptions(program
   .command('oracle-register <accountId> <queryFormat> <responseFormat>')
   .addArgument(nonceArgument)
   .addOption(ttlOption)
@@ -173,14 +172,14 @@ program
   .option('--queryFee [queryFee]', 'Oracle Query fee.', QUERY_FEE)
   .option('--oracleTtl [oracleTtl]', 'Oracle Ttl.', ORACLE_TTL.value)
   .description('Build oracle register transaction.')
-  .action(withGlobalOpts(Transaction.oracleRegister));
+  .action(Transaction.oracleRegister));
 
 // ## Initialize `oracle-post-query` command
 //
 // You can use this command to build `oracle-post-query` transaction
 //
 // Example: `aecli tx oracle-post-query ak_2a1j2Mk9YSmC1gioUq4PWRm3bsv887MbuRVwyv4KaUGoR1eiKi  ok_348hrfdhisdkhasdaksdasdsad {city: 'Berlin'}`
-program
+addCommonOptions(program
   .command('oracle-post-query <accountId> <oracleId> <query>')
   .addArgument(nonceArgument)
   .addOption(ttlOption)
@@ -189,44 +188,44 @@ program
   .option('--queryTtl [oracleTtl]', 'Oracle Ttl.', QUERY_TTL.value)
   .option('--responseTtl [oracleTtl]', 'Oracle Ttl.', RESPONSE_TTL)
   .description('Build oracle post query transaction.')
-  .action(withGlobalOpts(Transaction.oraclePostQuery));
+  .action(Transaction.oraclePostQuery));
 
 // ## Initialize `oracle-extend` command
 //
 // You can use this command to build `oracle-extend` transaction
 //
 // Example: `aecli tx oracle-extend ak_2a1j2Mk9YSmC1gioUq4PWRm3bsv887MbuRVwyv4KaUGoR1eiKi  ok_348hrfdhisdkhasdaksdasdsad 100
-program
+addCommonOptions(program
   .command('oracle-extend <callerId> <oracleId> <oracleTtl>')
   .addArgument(nonceArgument)
   .addOption(ttlOption)
   .addOption(feeOption)
   .description('Build oracle extend transaction.')
-  .action(withGlobalOpts(Transaction.oracleExtend));
+  .action(Transaction.oracleExtend));
 
 // ## Initialize `oracle-respond` command
 //
 // You can use this command to build `oracle-respond` transaction
 //
 // Example: `aecli tx oracle-respond ak_2a1j2Mk9YSmC1gioUq4PWRm3bsv887MbuRVwyv4KaUGoR1eiKi  ok_348hrfdhisdkhasdaksdasdsad oq_asdjn23ifsdiuhfk2h3fuksadh {tmp: 1}`
-program
+addCommonOptions(program
   .command('oracle-respond <callerId> <oracleId> <queryId> <response>')
   .addArgument(nonceArgument)
   .addOption(ttlOption)
   .addOption(feeOption)
   .option('--responseTtl [oracleTtl]', 'Oracle Ttl.', RESPONSE_TTL)
   .description('Build oracle extend transaction.')
-  .action(withGlobalOpts(Transaction.oracleRespond));
+  .action(Transaction.oracleRespond));
 
 // ## Initialize `verify` command
 //
 // You can use this command to send `transaction` to the `chain`
 //
 // Example: `aecli tx spend ak_2a1j2Mk9YSmC1gioUq4PWRm3bsv887MbuRVwyv4KaUGoR1eiKi ak_AgV756Vfo99juwzNVgnjP1gXX1op1QN3NXTxvkPnHJPUDE8NT 100`
-program
+addCommonOptions(program
   .command('verify <tx>')
   .addOption(networkIdOption)
   .description('Verify transaction')
-  .action(withGlobalOpts(Transaction.verify));
+  .action(Transaction.verify));
 
 export default program;

--- a/src/commands/tx.js
+++ b/src/commands/tx.js
@@ -28,7 +28,7 @@ import { RESPONSE_TTL } from '../utils/constant';
 import { withGlobalOpts } from '../utils/cli';
 import * as Transaction from '../actions/transaction';
 import {
-  nodeOption, jsonOption, gasOption, nonceArgument, feeOption,
+  nodeOption, jsonOption, gasOption, nonceArgument, feeOption, forceOption,
 } from '../arguments';
 
 const program = new Command().name('aecli tx');
@@ -39,7 +39,7 @@ program
 // .option('--nonce [nonce]', 'Override the nonce that the transaction is going to be sent with')
   .addOption(feeOption)
   .option('--ttl [fee]', 'Override the ttl that the transaction is going to be sent with', TX_TTL)
-  .option('-f --force', 'Ignore node version compatibility check')
+  .addOption(forceOption)
   .addOption(jsonOption);
 
 // ## Initialize `spend` command

--- a/src/commands/tx.js
+++ b/src/commands/tx.js
@@ -28,7 +28,14 @@ import { RESPONSE_TTL } from '../utils/constant';
 import { withGlobalOpts } from '../utils/cli';
 import * as Transaction from '../actions/transaction';
 import {
-  nodeOption, jsonOption, gasOption, nonceArgument, feeOption, forceOption, ttlOption,
+  nodeOption,
+  jsonOption,
+  gasOption,
+  nonceArgument,
+  feeOption,
+  forceOption,
+  ttlOption,
+  networkIdOption,
 } from '../arguments';
 
 const program = new Command().name('aecli tx');
@@ -218,7 +225,7 @@ program
 // Example: `aecli tx spend ak_2a1j2Mk9YSmC1gioUq4PWRm3bsv887MbuRVwyv4KaUGoR1eiKi ak_AgV756Vfo99juwzNVgnjP1gXX1op1QN3NXTxvkPnHJPUDE8NT 100`
 program
   .command('verify <tx>')
-  .option('--networkId [networkId]', 'Network id (default: ae_mainnet)')
+  .addOption(networkIdOption)
   .description('Verify transaction')
   .action(withGlobalOpts(Transaction.verify));
 

--- a/src/commands/tx.js
+++ b/src/commands/tx.js
@@ -25,7 +25,7 @@ import {
   TX_TTL, NAME_TTL, CLIENT_TTL, MIN_GAS_PRICE, QUERY_FEE, ORACLE_TTL, QUERY_TTL,
 } from '@aeternity/aepp-sdk';
 import { RESPONSE_TTL } from '../utils/constant';
-import { getCmdFromArguments } from '../utils/cli';
+import { withGlobalOpts } from '../utils/cli';
 import * as Transaction from '../actions/transaction';
 import {
   nodeOption, jsonOption, gasOption, nonceArgument, feeOption,
@@ -52,7 +52,7 @@ program
   .addArgument(nonceArgument)
   .option('--payload [payload]', 'Transaction payload.', '')
   .description('Build Spend Transaction')
-  .action((senderId, receiverId, amount, nonce, ...args) => Transaction.spend(senderId, receiverId, amount, nonce, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Transaction.spend));
 
 // ## Initialize `name-preclaim` command
 //
@@ -63,7 +63,7 @@ program
   .command('name-preclaim <accountId> <domain>')
   .addArgument(nonceArgument)
   .description('Build name preclaim transaction.')
-  .action((accountId, domain, nonce, ...args) => Transaction.namePreClaim(accountId, domain, nonce, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Transaction.namePreClaim));
 
 // ## Initialize `name-update` command
 //
@@ -79,7 +79,7 @@ program
   .option('--nameTtl [nameTtl]', 'Validity of name.', NAME_TTL)
   .option('--clientTtl [clientTtl]', 'Client ttl.', CLIENT_TTL)
   .description('Build name update transaction.')
-  .action((accountId, domain, nonce, pointers, ...args) => Transaction.nameUpdate(accountId, domain, nonce, pointers, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Transaction.nameUpdate));
 
 // ## Initialize `name-claim` command
 //
@@ -93,7 +93,7 @@ program
   .addOption(feeOption)
   .option('--nameFee [nameFee]', 'Name fee.')
   .description('Build name claim transaction.')
-  .action((accountId, salt, domain, nonce, ...args) => Transaction.nameClaim(accountId, salt, domain, nonce, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Transaction.nameClaim));
 
 // ## Initialize `name-transfer` command
 //
@@ -106,7 +106,7 @@ program
   .option('-T, --ttl [ttl]', 'Validity of the transaction in number of blocks (default forever)', TX_TTL)
   .addOption(feeOption)
   .description('Build name tansfer transaction.')
-  .action((accountId, transferId, domain, nonce, ...args) => Transaction.nameTransfer(accountId, transferId, domain, nonce, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Transaction.nameTransfer));
 
 // ## Initialize `name-revoke` command
 //
@@ -119,7 +119,7 @@ program
   .option('-T, --ttl [ttl]', 'Validity of the transaction in number of blocks (default forever)', TX_TTL)
   .addOption(feeOption)
   .description('Build name revoke transaction.')
-  .action((accountId, domain, nonce, ...args) => Transaction.nameRevoke(accountId, domain, nonce, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Transaction.nameRevoke));
 
 // ## Initialize `contract-deploy` command
 //
@@ -135,7 +135,7 @@ program
   .option('-G --gasPrice [gas]', 'Amount of gas to deploy the contract', MIN_GAS_PRICE)
   .option('--amount [amount]', 'Amount', 0)
   .description('Build contract create transaction.')
-  .action((ownerId, contractBytecode, initCallData, nonce, ...args) => Transaction.contractDeploy(ownerId, contractBytecode, initCallData, nonce, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Transaction.contractDeploy));
 
 // ## Initialize `contract-call` command
 //
@@ -151,7 +151,7 @@ program
   .option('-G --gasPrice [gas]', 'Amount of gas to deploy the contract', MIN_GAS_PRICE)
   .option('--amount [amount]', 'Amount', 0)
   .description('Build contract create transaction.')
-  .action((callerId, contractId, callData, nonce, ...args) => Transaction.contractCall(callerId, contractId, callData, nonce, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Transaction.contractCall));
 
 // ## Initialize `oracle-register` command
 //
@@ -166,7 +166,7 @@ program
   .option('--queryFee [queryFee]', 'Oracle Query fee.', QUERY_FEE)
   .option('--oracleTtl [oracleTtl]', 'Oracle Ttl.', ORACLE_TTL.value)
   .description('Build oracle register transaction.')
-  .action((accountId, queryFormat, responseFormat, nonce, ...args) => Transaction.oracleRegister(accountId, queryFormat, responseFormat, nonce, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Transaction.oracleRegister));
 
 // ## Initialize `oracle-post-query` command
 //
@@ -182,7 +182,7 @@ program
   .option('--queryTtl [oracleTtl]', 'Oracle Ttl.', QUERY_TTL.value)
   .option('--responseTtl [oracleTtl]', 'Oracle Ttl.', RESPONSE_TTL)
   .description('Build oracle post query transaction.')
-  .action((accountId, oracleId, query, nonce, ...args) => Transaction.oraclePostQuery(accountId, oracleId, query, nonce, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Transaction.oraclePostQuery));
 
 // ## Initialize `oracle-extend` command
 //
@@ -195,7 +195,7 @@ program
   .option('-T, --ttl [ttl]', 'Validity of the transaction in number of blocks (default forever)', TX_TTL)
   .addOption(feeOption)
   .description('Build oracle extend transaction.')
-  .action((callerId, oracleId, oracleTtl, nonce, ...args) => Transaction.oracleExtend(callerId, oracleId, oracleTtl, nonce, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Transaction.oracleExtend));
 
 // ## Initialize `oracle-respond` command
 //
@@ -209,7 +209,7 @@ program
   .addOption(feeOption)
   .option('--responseTtl [oracleTtl]', 'Oracle Ttl.', RESPONSE_TTL)
   .description('Build oracle extend transaction.')
-  .action((callerId, oracleId, queryId, response, nonce, ...args) => Transaction.oracleRespond(callerId, oracleId, queryId, response, nonce, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Transaction.oracleRespond));
 
 // ## Initialize `verify` command
 //
@@ -220,6 +220,6 @@ program
   .command('verify <tx>')
   .option('--networkId [networkId]', 'Network id (default: ae_mainnet)')
   .description('Verify transaction')
-  .action((tx, ...args) => Transaction.verify(tx, getCmdFromArguments(args)));
+  .action(withGlobalOpts(Transaction.verify));
 
 export default program;

--- a/src/utils/CliError.js
+++ b/src/utils/CliError.js
@@ -1,4 +1,5 @@
 import { InvalidPasswordError } from '@aeternity/aepp-sdk';
+import { setCommandOptions } from './config';
 
 export default class CliError extends Error {
   constructor(message) {
@@ -9,6 +10,7 @@ export default class CliError extends Error {
 
 export async function runProgram(program) {
   try {
+    await setCommandOptions(program);
     await program.parseAsync();
   } catch (error) {
     if (

--- a/src/utils/cli.js
+++ b/src/utils/cli.js
@@ -19,10 +19,11 @@
 import { AeSdk, Node, MemoryAccount } from '@aeternity/aepp-sdk';
 import { getWalletByPathAndDecrypt } from './account';
 
-// ## Merge options with parent options.
-export function getCmdFromArguments([options, commander]) {
-  return { ...options, ...commander.parent.opts() };
-}
+export const withGlobalOpts = (fn) => (...args) => {
+  const commander = args.pop();
+  args.pop();
+  return fn(...args, commander.optsWithGlobals());
+};
 
 export async function initSdk({
   url, keypair, compilerUrl, force: ignoreVersion, networkId, accounts = [],

--- a/src/utils/cli.js
+++ b/src/utils/cli.js
@@ -19,12 +19,6 @@
 import { AeSdk, Node, MemoryAccount } from '@aeternity/aepp-sdk';
 import { getWalletByPathAndDecrypt } from './account';
 
-export const withGlobalOpts = (fn) => (...args) => {
-  const commander = args.pop();
-  args.pop();
-  return fn(...args, commander.optsWithGlobals());
-};
-
 export async function initSdk({
   url, keypair, compilerUrl, force: ignoreVersion, networkId, accounts = [],
 } = {}) {

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,0 +1,28 @@
+import envPaths from 'env-paths';
+import fs from 'fs-extra';
+import path from 'path';
+
+const configPath = path.resolve(envPaths('aecli').config, 'config.json');
+const options = ['url', 'compilerUrl'];
+
+async function readConfig() {
+  try {
+    return await fs.readJson(configPath);
+  } catch {
+    return {};
+  }
+}
+
+export async function addToConfig(configPart) {
+  await fs.outputJson(configPath, { ...await readConfig(), ...configPart });
+}
+
+const configPromise = readConfig();
+
+export async function setCommandOptions(program) {
+  const config = await configPromise;
+  options
+    .filter((option) => option in config)
+    .forEach((option) => program.setOptionValueWithSource(option, config[option], 'config'));
+  program.commands.forEach(setCommandOptions);
+}

--- a/test/index.js
+++ b/test/index.js
@@ -88,7 +88,9 @@ export async function executeProgram(program, args) {
   try {
     const allArgs = [
       ...args.map((arg) => arg.toString()),
-      ...['config', 'decode', 'sign', 'unpack'].includes(args[0]) ? [] : ['--url', url],
+      ...[
+        'config', 'decode', 'sign', 'unpack', 'select-node', 'select-compiler',
+      ].includes(args[0]) ? [] : ['--url', url],
       ...args[0] === 'contract' ? ['--compilerUrl', compilerUrl] : [],
     ];
     if (allArgs.some((a) => !['string', 'number'].includes(typeof a))) {

--- a/test/other.js
+++ b/test/other.js
@@ -22,10 +22,24 @@ import mainProgram from '../src/commands/main';
 
 describe('Other tests', () => {
   it('Config', async () => {
-    const config = await executeProgram(mainProgram, ['config']);
-    expect(config).to.include('NODE_URL');
-    expect(config).to.include('COMPILER_URL');
-    expect(config).to.not.include('undefined');
-    expect(config.split('http')).to.have.length(3);
+    expect(await executeProgram(mainProgram, ['config'])).to.equal(
+      'Node https://testnet.aeternity.io network id ae_uat, version 6.6.0\n'
+      + 'Compiler https://compiler.aepps.com version 6.1.0',
+    );
+  });
+
+  it('selects node', async () => {
+    expect(await executeProgram(mainProgram, ['select-node', 'http://example.com/node']))
+      .to.equal('');
+  });
+
+  it('fails if invalid url', async () => {
+    await expect(executeProgram(mainProgram, ['select-node', 'example.com/node']))
+      .to.be.rejectedWith('Invalid URL');
+  });
+
+  it('selects compiler', async () => {
+    expect(await executeProgram(mainProgram, ['select-compiler', 'http://example.com/node']))
+      .to.equal('');
   });
 });


### PR DESCRIPTION
closes #210 

```
aecli contract call --help
Usage: aecli contract call [options] <fn> [args] [wallet_path]

Execute a function of the contract

Arguments:
  fn                                   Name of contract entrypoint to call
  args                                 JSON-encoded arguments array of contract call (default: [])
  wallet_path                          Path to secret storage file

Options:
  -d --descrPath [descrPath]           Path to contract descriptor file
  --contractAddress [contractAddress]  Contract address to call
  --contractSource [contractSource]    Contract source code file name
  --contractAci [contractAci]          Contract ACI file name
  -W, --no-waitMined                   Force waiting until transaction will be mined
  --networkId [networkId]              Network id
  -P, --password [password]            Wallet Password
  -G --gas [gas]                       Amount of gas to call/deploy the contract
  -s --callStatic                      Call static
  -t --topHash                         Hash of block to make call
  -F, --fee [fee]                      Override the transaction fee
  -T, --ttl [ttl]                      Validity of the transaction in number of blocks (default: forever)
  -N, --nonce [nonce]                  Override the nonce that the transaction is going to be sent with
  -u, --url [nodeUrl]                  Node to connect to (default: Aeternity testnet, env: AECLI_NODE_URL)
  --compilerUrl [compilerUrl]          Compiler to connect to (default: Stable compiler, env: AECLI_COMPILER_URL)
  -f --force                           Ignore node version compatibility check
  --json                               Print result in json format
  -h, --help                           display help for command
```