### PR TITLE
fix(contract): don't show stacktrace if static contract call failed

### DIFF
--- a/src/utils/CliError.js
+++ b/src/utils/CliError.js
@@ -1,4 +1,4 @@
-import { InvalidPasswordError } from '@aeternity/aepp-sdk';
+import { InvalidPasswordError, NodeInvocationError } from '@aeternity/aepp-sdk';
 import { setCommandOptions } from './config.js';
 import { prepareOptions } from './default-option-description.js';
 
@@ -18,6 +18,7 @@ export async function runProgram(program) {
     if (
       error instanceof CliError
       || error instanceof InvalidPasswordError
+      || error instanceof NodeInvocationError
       || error.code === 'ENOENT'
     ) {
       program.error(error.message);


### PR DESCRIPTION
closes #209

This PR is supported by the Æternity Foundation

Steps to reproduce
```
wget https://raw.githubusercontent.com/aeternity/aestudio/d9a5809/src/app/contracts/AeForUsers.aes
./src/aecli.js account save ./my-wallet.json 9ebd7beda0c79af72a42ece3821a56eff16359b6df376cf049aee995565f022f840c974b97164776454ba119d84edc4d6058a8dec92b6edc578ab2d30b4c4200
./src/aecli.js select-node https://testnet.aeternity.io/
./src/aecli.js select-compiler https://v7.compiler.aepps.com/
./src/aecli.js contract deploy ./my-wallet.json "[]" --contractSource ./AeForUsers.aes
./src/aecli.js contract call checkUserBalance "[]" ./my-wallet.json --contractAddress ct_Lrxejgqu19if5QSBrLmV12fnNPfNWpXF33pGuLiE4uAUQUjqu --contractSource ./AeForUsers.aes
```
Output before
```
file:///.../aepp-cli-js/node_modules/@aeternity/aepp-sdk/es/contract/Contract.mjs:479
  throw new NodeInvocationError(message, transaction);
        ^

NodeInvocationError: Invocation failed: "Maps: Key does not exist"
    at Contract._getCallResult2 (file:///.../aepp-cli-js/node_modules/@aeternity/aepp-sdk/es/contract/Contract.mjs:479:9)
    at Contract.$call (file:///.../aepp-cli-js/node_modules/@aeternity/aepp-sdk/es/contract/Contract.mjs:257:74)
```
Output after
```
Invocation failed: "Maps: Key does not exist"
```
So the command output doesn't look like an internal error. 