### PR TITLE
refactor: rename `sdk` to `aeSdk` in consistency with sdk tests

### DIFF
--- a/src/actions/account.js
+++ b/src/actions/account.js
@@ -42,10 +42,10 @@ export async function verifyMessage(address, hexSignature, dataArray = [], optio
 }
 
 export async function sign(walletPath, tx, { networkId: networkIdOpt, json, ...options }) {
-  const sdk = await initSdkByWalletFile(walletPath, options);
-  const networkId = networkIdOpt ?? await sdk.api.getNetworkId();
-  const signedTx = await sdk.signTransaction(tx, { networkId });
-  const { address } = sdk;
+  const aeSdk = await initSdkByWalletFile(walletPath, options);
+  const networkId = networkIdOpt ?? await aeSdk.api.getNetworkId();
+  const signedTx = await aeSdk.signTransaction(tx, { networkId });
+  const { address } = aeSdk;
   if (json) {
     print({ signedTx, address, networkId });
   } else {

--- a/src/actions/aens.js
+++ b/src/actions/aens.js
@@ -4,8 +4,8 @@ import { printTransaction } from '../utils/print.js';
 import { getNameEntry, validateName } from '../utils/helpers.js';
 import CliError from '../utils/CliError.js';
 
-async function ensureNameStatus(name, sdk, status, operation) {
-  const nameEntry = await getNameEntry(name, sdk);
+async function ensureNameStatus(name, aeSdk, status, operation) {
+  const nameEntry = await getNameEntry(name, aeSdk);
   if (nameEntry.status !== status) {
     throw new CliError(`AENS name is ${nameEntry.status} and cannot be ${operation}`);
   }
@@ -16,10 +16,10 @@ export async function preClaim(walletPath, name, options) {
     ttl, fee, nonce, json,
   } = options;
   validateName(name);
-  const sdk = await initSdkByWalletFile(walletPath, options);
-  await ensureNameStatus(name, sdk, 'AVAILABLE', 'preclaimed');
-  const preClaimTx = await sdk.aensPreclaim(name, { ttl, fee, nonce });
-  await printTransaction(preClaimTx, json, sdk);
+  const aeSdk = await initSdkByWalletFile(walletPath, options);
+  await ensureNameStatus(name, aeSdk, 'AVAILABLE', 'preclaimed');
+  const preClaimTx = await aeSdk.aensPreclaim(name, { ttl, fee, nonce });
+  await printTransaction(preClaimTx, json, aeSdk);
 }
 
 export async function claim(walletPath, name, salt, options) {
@@ -27,12 +27,12 @@ export async function claim(walletPath, name, salt, options) {
     ttl, fee, nonce, json, nameFee,
   } = options;
   validateName(name);
-  const sdk = await initSdkByWalletFile(walletPath, options);
-  await ensureNameStatus(name, sdk, 'AVAILABLE', 'claimed');
-  const claimTx = await sdk.aensClaim(name, salt, {
+  const aeSdk = await initSdkByWalletFile(walletPath, options);
+  await ensureNameStatus(name, aeSdk, 'AVAILABLE', 'claimed');
+  const claimTx = await aeSdk.aensClaim(name, salt, {
     nonce, ttl, fee, nameFee,
   });
-  await printTransaction(claimTx, json, sdk);
+  await printTransaction(claimTx, json, aeSdk);
 }
 
 export async function updateName(walletPath, name, addresses, options) {
@@ -42,16 +42,16 @@ export async function updateName(walletPath, name, addresses, options) {
   const invalidAddresses = addresses.filter((address) => !isAddressValid(address));
   if (invalidAddresses.length) throw new CliError(`Addresses "[${invalidAddresses}]" is not valid`);
   validateName(name);
-  const sdk = await initSdkByWalletFile(walletPath, options);
-  await ensureNameStatus(name, sdk, 'CLAIMED', 'updated');
-  const updateTx = await sdk.aensUpdate(
+  const aeSdk = await initSdkByWalletFile(walletPath, options);
+  await ensureNameStatus(name, aeSdk, 'CLAIMED', 'updated');
+  const updateTx = await aeSdk.aensUpdate(
     name,
     Object.fromEntries(addresses.map((address) => [getDefaultPointerKey(address), address])),
     {
       ttl, fee, nonce, nameTtl, clientTtl, extendPointers,
     },
   );
-  await printTransaction(updateTx, json, sdk);
+  await printTransaction(updateTx, json, aeSdk);
 }
 
 export async function extendName(walletPath, name, nameTtl, options) {
@@ -59,12 +59,12 @@ export async function extendName(walletPath, name, nameTtl, options) {
     ttl, fee, nonce, json,
   } = options;
   validateName(name);
-  const sdk = await initSdkByWalletFile(walletPath, options);
-  await ensureNameStatus(name, sdk, 'CLAIMED', 'extended');
-  const updateTx = await sdk.aensUpdate(name, {}, {
+  const aeSdk = await initSdkByWalletFile(walletPath, options);
+  await ensureNameStatus(name, aeSdk, 'CLAIMED', 'extended');
+  const updateTx = await aeSdk.aensUpdate(name, {}, {
     ttl, fee, nonce, nameTtl, extendPointers: true,
   });
-  await printTransaction(updateTx, json, sdk);
+  await printTransaction(updateTx, json, aeSdk);
 }
 
 export async function transferName(walletPath, name, address, options) {
@@ -73,10 +73,10 @@ export async function transferName(walletPath, name, address, options) {
   } = options;
   if (!isAddressValid(address)) throw new CliError(`Address "${address}" is not valid`);
   validateName(name);
-  const sdk = await initSdkByWalletFile(walletPath, options);
-  await ensureNameStatus(name, sdk, 'CLAIMED', 'transferred');
-  const transferTX = await sdk.aensTransfer(name, address, { ttl, fee, nonce });
-  await printTransaction(transferTX, json, sdk);
+  const aeSdk = await initSdkByWalletFile(walletPath, options);
+  await ensureNameStatus(name, aeSdk, 'CLAIMED', 'transferred');
+  const transferTX = await aeSdk.aensTransfer(name, address, { ttl, fee, nonce });
+  await printTransaction(transferTX, json, aeSdk);
 }
 
 export async function revokeName(walletPath, name, options) {
@@ -84,10 +84,10 @@ export async function revokeName(walletPath, name, options) {
     ttl, fee, nonce, json,
   } = options;
   validateName(name);
-  const sdk = await initSdkByWalletFile(walletPath, options);
-  await ensureNameStatus(name, sdk, 'CLAIMED', 'revoked');
-  const revokeTx = await sdk.aensRevoke(name, { ttl, fee, nonce });
-  await printTransaction(revokeTx, json, sdk);
+  const aeSdk = await initSdkByWalletFile(walletPath, options);
+  await ensureNameStatus(name, aeSdk, 'CLAIMED', 'revoked');
+  const revokeTx = await aeSdk.aensRevoke(name, { ttl, fee, nonce });
+  await printTransaction(revokeTx, json, aeSdk);
 }
 
 export async function nameBid(walletPath, name, nameFee, options) {
@@ -95,10 +95,10 @@ export async function nameBid(walletPath, name, nameFee, options) {
     ttl, fee, nonce, json,
   } = options;
   validateName(name);
-  const sdk = await initSdkByWalletFile(walletPath, options);
-  await ensureNameStatus(name, sdk, 'AUCTION', 'bidded');
-  const nameBidTx = await sdk.aensBid(name, nameFee, { nonce, ttl, fee });
-  await printTransaction(nameBidTx, json, sdk);
+  const aeSdk = await initSdkByWalletFile(walletPath, options);
+  await ensureNameStatus(name, aeSdk, 'AUCTION', 'bidded');
+  const nameBidTx = await aeSdk.aensBid(name, nameFee, { nonce, ttl, fee });
+  await printTransaction(nameBidTx, json, aeSdk);
 }
 
 export async function fullClaim(walletPath, name, options) {
@@ -107,10 +107,10 @@ export async function fullClaim(walletPath, name, options) {
   } = options;
   validateName(name);
   if (name.split('.')[0] < 13) throw new CliError('Full name claiming works only with name longer then 12 symbol (not trigger auction)');
-  const sdk = await initSdkByWalletFile(walletPath, options);
-  await ensureNameStatus(name, sdk, 'AVAILABLE', 'claimed');
+  const aeSdk = await initSdkByWalletFile(walletPath, options);
+  await ensureNameStatus(name, aeSdk, 'AVAILABLE', 'claimed');
   nonce = nonce && +nonce;
-  const preclaim = await sdk.aensPreclaim(name, { nonce, ttl, fee });
+  const preclaim = await aeSdk.aensPreclaim(name, { nonce, ttl, fee });
 
   nonce = nonce && nonce + 1;
   const nameInstance = await preclaim.claim({
@@ -119,10 +119,10 @@ export async function fullClaim(walletPath, name, options) {
 
   nonce = nonce && nonce + 1;
   const updateTx = await nameInstance.update(
-    { account_pubkey: sdk.address },
+    { account_pubkey: aeSdk.address },
     {
       nonce, ttl, fee, nameTtl, clientTtl,
     },
   );
-  await printTransaction(updateTx, json, sdk);
+  await printTransaction(updateTx, json, aeSdk);
 }

--- a/src/actions/chain.js
+++ b/src/actions/chain.js
@@ -7,9 +7,9 @@ import { getBlock } from '../utils/helpers.js';
 
 export async function status(options) {
   const { json } = options;
-  const sdk = initSdk(options);
-  const st = await sdk.api.getStatus();
-  const { consensusProtocolVersion } = await sdk.getNodeInfo();
+  const aeSdk = initSdk(options);
+  const st = await aeSdk.api.getStatus();
+  const { consensusProtocolVersion } = await aeSdk.getNodeInfo();
   if (json) {
     print(st);
     return;
@@ -28,8 +28,8 @@ export async function status(options) {
 }
 
 export async function ttl(_absoluteTtl, { json, ...options }) {
-  const sdk = initSdk(options);
-  const height = await sdk.getHeight();
+  const aeSdk = initSdk(options);
+  const height = await aeSdk.getHeight();
   const absoluteTtl = +_absoluteTtl;
   const relativeTtl = absoluteTtl - height;
   if (json) {
@@ -41,38 +41,38 @@ export async function ttl(_absoluteTtl, { json, ...options }) {
 }
 
 export async function top({ json, ...options }) {
-  const sdk = initSdk(options);
-  printBlock(await sdk.api.getTopHeader(), json, true);
+  const aeSdk = initSdk(options);
+  printBlock(await aeSdk.api.getTopHeader(), json, true);
 }
 
 export async function play(options) {
   let { height, limit, json } = options;
   limit = +limit;
   height = +height;
-  const sdk = initSdk(options);
-  let block = await sdk.api.getTopHeader();
+  const aeSdk = initSdk(options);
+  let block = await aeSdk.api.getTopHeader();
   while (height ? block.height >= height : limit) {
     if (!height) limit -= 1;
     printBlock(block, json);
-    block = await getBlock(block.prevHash, sdk); // eslint-disable-line no-await-in-loop
+    block = await getBlock(block.prevHash, aeSdk); // eslint-disable-line no-await-in-loop
   }
 }
 
 export async function broadcast(signedTx, options) {
   const { json, waitMined, verify } = options;
-  const sdk = initSdk(options);
+  const aeSdk = initSdk(options);
 
   if (verify) {
-    const validation = await verifyTransaction(signedTx, sdk.api);
+    const validation = await verifyTransaction(signedTx, aeSdk.api);
     if (validation.length) {
       printValidation({ validation, transaction: signedTx });
       return;
     }
   }
 
-  const { txHash } = await sdk.api.postTransaction({ tx: signedTx });
-  const tx = await (waitMined ? sdk.poll(txHash) : sdk.api.getTransactionByHash(txHash));
+  const { txHash } = await aeSdk.api.postTransaction({ tx: signedTx });
+  const tx = await (waitMined ? aeSdk.poll(txHash) : aeSdk.api.getTransactionByHash(txHash));
 
-  await printTransaction(tx, json, sdk);
+  await printTransaction(tx, json, aeSdk);
   if (!waitMined && !json) print('Transaction send to the chain.');
 }

--- a/src/actions/contract.js
+++ b/src/actions/contract.js
@@ -32,18 +32,18 @@ async function getContractParams({
 }
 
 export async function compile(contractSource, options) {
-  const sdk = initSdk(options);
-  const contract = await sdk.initializeContract({ sourceCodePath: contractSource });
+  const aeSdk = initSdk(options);
+  const contract = await aeSdk.initializeContract({ sourceCodePath: contractSource });
   const bytecode = await contract.$compile();
   if (options.json) print({ bytecode });
   else print(`Contract bytecode: ${bytecode}`);
 }
 
 export async function encodeCalldata(fn, args, options) {
-  const sdk = initSdk(options);
+  const aeSdk = initSdk(options);
   const contractParams = await getContractParams(options, { dummyBytecode: true });
   delete contractParams.address; // TODO: remove after dropping Iris support
-  const contract = await sdk.initializeContract(contractParams);
+  const contract = await aeSdk.initializeContract(contractParams);
   // eslint-disable-next-line no-underscore-dangle
   const calldata = contract._calldata.encode(contract._name, fn, args);
   if (options.json) print({ calldata });
@@ -51,8 +51,8 @@ export async function encodeCalldata(fn, args, options) {
 }
 
 export async function decodeCallResult(fn, calldata, options) {
-  const sdk = initSdk(options);
-  const contract = await sdk.initializeContract(await getContractParams(options, { dummyBytecode: true }));
+  const aeSdk = initSdk(options);
+  const contract = await aeSdk.initializeContract(await getContractParams(options, { dummyBytecode: true }));
   // eslint-disable-next-line no-underscore-dangle
   const decoded = contract._calldata.decode(contract._name, fn, calldata);
   if (options.json) print({ decoded });
@@ -63,8 +63,8 @@ export async function decodeCallResult(fn, calldata, options) {
 }
 
 export async function deploy(walletPath, args, options) {
-  const sdk = await initSdkByWalletFile(walletPath, options);
-  const contract = await sdk.initializeContract(await getContractParams(options, { descrMayNotExist: true }));
+  const aeSdk = await initSdkByWalletFile(walletPath, options);
+  const contract = await aeSdk.initializeContract(await getContractParams(options, { descrMayNotExist: true }));
   const result = await contract.$deploy(args, options);
   const filename = options.contractSource ?? options.contractBytecode;
   options.descrPath ??= getFullPath(`${filename}.deploy.${result.address.slice(3)}.json`);
@@ -92,8 +92,8 @@ export async function call(fn, args, walletPath, options) {
   if (callStatic !== true && walletPath == null) {
     throw new CliError('wallet_path is required for on-chain calls');
   }
-  const sdk = await initSdkByWalletFile(walletPath, options);
-  const contract = await sdk.initializeContract(await getContractParams(options));
+  const aeSdk = await initSdkByWalletFile(walletPath, options);
+  const contract = await aeSdk.initializeContract(await getContractParams(options));
   const callResult = await contract.$call(fn, args, {
     ttl: ttl && +ttl,
     gas,
@@ -105,7 +105,7 @@ export async function call(fn, args, walletPath, options) {
   });
   if (json) print(callResult);
   else {
-    await printTransaction(callResult.txData, json, sdk);
+    await printTransaction(callResult.txData, json, aeSdk);
     print('----------------------Call info-----------------------');
     const gasCoins = BigInt(callResult.result.gasUsed) * callResult.txData.tx.gasPrice;
     printUnderscored('Gas used', `${callResult.result.gasUsed} (${formatCoins(gasCoins)})`);

--- a/src/actions/inspect.js
+++ b/src/actions/inspect.js
@@ -18,14 +18,14 @@ function printEntries(object) {
 
 async function getBlockByHash(hash, { json, ...options }) {
   checkPref(hash, [Encoding.KeyBlockHash, Encoding.MicroBlockHash]);
-  const sdk = initSdk(options);
-  printBlock(await getBlock(hash, sdk), json, true);
+  const aeSdk = initSdk(options);
+  printBlock(await getBlock(hash, aeSdk), json, true);
 }
 
 async function getTransactionByHash(hash, { json, ...options }) {
   checkPref(hash, Encoding.TxHash);
-  const sdk = initSdk(options);
-  await printTransaction(await sdk.api.getTransactionByHash(hash), json, sdk);
+  const aeSdk = initSdk(options);
+  await printTransaction(await aeSdk.api.getTransactionByHash(hash), json, aeSdk);
 }
 
 async function unpackTx(encodedTx, { json }) {
@@ -38,10 +38,10 @@ async function unpackTx(encodedTx, { json }) {
 
 async function getAccountByHash(hash, { json, ...options }) {
   checkPref(hash, Encoding.AccountAddress);
-  const sdk = initSdk(options);
-  const { nonce } = await sdk.api.getAccountByPubkey(hash);
-  const balance = await sdk.getBalance(hash);
-  const { transactions } = await sdk.api.getPendingAccountTransactionsByPubkey(hash);
+  const aeSdk = initSdk(options);
+  const { nonce } = await aeSdk.api.getAccountByPubkey(hash);
+  const balance = await aeSdk.getBalance(hash);
+  const { transactions } = await aeSdk.api.getPendingAccountTransactionsByPubkey(hash);
   if (json) {
     print({
       hash,
@@ -59,21 +59,21 @@ async function getAccountByHash(hash, { json, ...options }) {
 }
 
 async function getBlockByHeight(height, { json, ...options }) {
-  const sdk = initSdk(options);
-  printBlock(await sdk.api.getKeyBlockByHeight(+height), json);
+  const aeSdk = initSdk(options);
+  printBlock(await aeSdk.api.getKeyBlockByHeight(+height), json);
 }
 
 async function getName(name, { json, ...options }) {
   validateName(name);
-  const sdk = initSdk(options);
-  const nameEntry = await getNameEntry(name, sdk);
+  const aeSdk = initSdk(options);
+  const nameEntry = await getNameEntry(name, aeSdk);
 
   if (json) {
     print(nameEntry);
     return;
   }
 
-  const height = await sdk.getHeight({ cached: true });
+  const height = await aeSdk.getHeight({ cached: true });
   printUnderscored('Status', nameEntry.status);
   printUnderscored('Name hash', nameEntry.id);
   switch (nameEntry.status) {
@@ -98,16 +98,16 @@ async function getName(name, { json, ...options }) {
 }
 
 async function getContract(contractId, { json, ...options }) {
-  const sdk = initSdk(options);
-  const contract = await sdk.api.getContract(contractId);
+  const aeSdk = initSdk(options);
+  const contract = await aeSdk.api.getContract(contractId);
   if (json) print(contract);
   else printEntries(contract);
 }
 
 async function getOracle(oracleId, { json, ...options }) {
-  const sdk = initSdk(options);
-  const oracle = await sdk.api.getOracleByPubkey(oracleId);
-  oracle.queries = (await sdk.api.getOracleQueriesByPubkey(oracleId)).oracleQueries;
+  const aeSdk = initSdk(options);
+  const oracle = await aeSdk.api.getOracleByPubkey(oracleId);
+  oracle.queries = (await aeSdk.api.getOracleQueriesByPubkey(oracleId)).oracleQueries;
   if (json) {
     print(oracle);
     return;

--- a/src/actions/oracle.js
+++ b/src/actions/oracle.js
@@ -14,8 +14,8 @@ export async function createOracle(walletPath, queryFormat, responseFormat, opti
   } = options;
 
   ensureTtlANumber(oracleTtl, 'Oracle');
-  const sdk = await initSdkByWalletFile(walletPath, options);
-  const oracle = await sdk.registerOracle(queryFormat, responseFormat, {
+  const aeSdk = await initSdkByWalletFile(walletPath, options);
+  const oracle = await aeSdk.registerOracle(queryFormat, responseFormat, {
     ttl,
     nonce,
     fee,
@@ -25,7 +25,7 @@ export async function createOracle(walletPath, queryFormat, responseFormat, opti
     },
     queryFee,
   });
-  await printTransaction(oracle, json, sdk);
+  await printTransaction(oracle, json, aeSdk);
 }
 
 export async function extendOracle(walletPath, oracleTtl, options) {
@@ -34,8 +34,8 @@ export async function extendOracle(walletPath, oracleTtl, options) {
   } = options;
 
   ensureTtlANumber(oracleTtl, 'Oracle');
-  const sdk = await initSdkByWalletFile(walletPath, options);
-  const oracle = await sdk.getOracleObject(sdk.address.replace('ak_', 'ok_'));
+  const aeSdk = await initSdkByWalletFile(walletPath, options);
+  const oracle = await aeSdk.getOracleObject(aeSdk.address.replace('ak_', 'ok_'));
   const extended = await oracle.extendOracle({
     ttl,
     nonce,
@@ -45,7 +45,7 @@ export async function extendOracle(walletPath, oracleTtl, options) {
       oracleTtlValue: oracleTtl,
     },
   });
-  await printTransaction(extended, json, sdk);
+  await printTransaction(extended, json, aeSdk);
 }
 
 export async function createOracleQuery(walletPath, oracleId, query, options) {
@@ -54,11 +54,11 @@ export async function createOracleQuery(walletPath, oracleId, query, options) {
   } = options;
 
   decode(oracleId, 'ok');
-  const sdk = await initSdkByWalletFile(walletPath, options);
+  const aeSdk = await initSdkByWalletFile(walletPath, options);
 
   ensureTtlANumber(queryTtl, 'Query');
   ensureTtlANumber(responseTtl, 'Response');
-  const oracle = await sdk.getOracleObject(oracleId);
+  const oracle = await aeSdk.getOracleObject(oracleId);
   const oracleQuery = await oracle.postQuery(query, {
     ttl,
     nonce,
@@ -73,7 +73,7 @@ export async function createOracleQuery(walletPath, oracleId, query, options) {
     },
     queryFee,
   });
-  await printTransaction(oracleQuery, json, sdk);
+  await printTransaction(oracleQuery, json, aeSdk);
 }
 
 export async function respondToQuery(walletPath, queryId, response, options) {
@@ -83,9 +83,9 @@ export async function respondToQuery(walletPath, queryId, response, options) {
 
   decode(queryId, 'oq');
   ensureTtlANumber(responseTtl, 'Response');
-  const sdk = await initSdkByWalletFile(walletPath, options);
+  const aeSdk = await initSdkByWalletFile(walletPath, options);
 
-  const oracle = await sdk.getOracleObject(sdk.address.replace('ak_', 'ok_'));
+  const oracle = await aeSdk.getOracleObject(aeSdk.address.replace('ak_', 'ok_'));
   const queryResponse = await oracle.respondToQuery(queryId, response, {
     ttl,
     nonce,
@@ -95,5 +95,5 @@ export async function respondToQuery(walletPath, queryId, response, options) {
       responseTtlValue: responseTtl,
     },
   });
-  await printTransaction(queryResponse, json, sdk);
+  await printTransaction(queryResponse, json, aeSdk);
 }

--- a/src/commands/spend.js
+++ b/src/commands/spend.js
@@ -42,8 +42,8 @@ const command = new Command('spend')
       ttl, json, nonce, fee, payload, ...options
     },
   ) => {
-    const sdk = await initSdkByWalletFile(walletPath, options);
-    const tx = await sdk[amount != null ? 'spend' : 'transferFunds'](
+    const aeSdk = await initSdkByWalletFile(walletPath, options);
+    const tx = await aeSdk[amount != null ? 'spend' : 'transferFunds'](
       amount ?? fraction / 100,
       receiverNameOrAddress,
       {
@@ -51,7 +51,7 @@ const command = new Command('spend')
       },
     );
     if (!json) print('Transaction mined');
-    await printTransaction(tx, json, sdk);
+    await printTransaction(tx, json, aeSdk);
   });
 
 addExamples(command, [

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -28,15 +28,15 @@ export const addExamples = (command, examples) => {
   });
 };
 
-export async function getBlock(hash, sdk) {
+export async function getBlock(hash, aeSdk) {
   const type = hash.split('_')[0];
   switch (type) {
     case Encoding.KeyBlockHash:
-      return sdk.api.getKeyBlockByHash(hash);
+      return aeSdk.api.getKeyBlockByHash(hash);
     case Encoding.MicroBlockHash:
       return {
-        ...await sdk.api.getMicroBlockHeaderByHash(hash),
-        ...await sdk.api.getMicroBlockTransactionsByHash(hash),
+        ...await aeSdk.api.getMicroBlockHeaderByHash(hash),
+        ...await aeSdk.api.getMicroBlockTransactionsByHash(hash),
       };
     default:
       throw new CliError(`Unknown block hash type: ${type}`);
@@ -64,15 +64,15 @@ export function checkPref(hash, hashType) {
   }
 }
 
-export async function getNameEntry(nameAsString, sdk) {
+export async function getNameEntry(nameAsString, aeSdk) {
   const [name, auction] = await Promise.all([
-    sdk.api.getNameEntryByName(nameAsString).catch((error) => {
+    aeSdk.api.getNameEntryByName(nameAsString).catch((error) => {
       if (error.response?.status === 404) {
         return error.response.parsedBody?.reason === 'Name revoked' ? 'REVOKED' : 'AVAILABLE';
       }
       throw error;
     }),
-    sdk.api.getAuctionEntryByName(nameAsString).catch((error) => {
+    aeSdk.api.getAuctionEntryByName(nameAsString).catch((error) => {
       if (error.response?.status === 404) return undefined;
       throw error;
     }),

--- a/src/utils/print.js
+++ b/src/utils/print.js
@@ -128,8 +128,8 @@ function printTransactionSync(_tx, json, currentHeight) {
   printTxField(tx, 'TTL', 'ttl', formatTtl);
 }
 
-export async function printTransaction(tx, json, sdk) {
-  const height = await sdk.getHeight({ cache: true });
+export async function printTransaction(tx, json, aeSdk) {
+  const height = await aeSdk.getHeight({ cache: true });
   printTransactionSync(tx, json, height);
 }
 

--- a/test/account.js
+++ b/test/account.js
@@ -15,11 +15,11 @@ describe('Account Module', () => {
   const fileName = 'test-artifacts/message.txt';
   const fileData = 'Hello world!';
   const keypair = generateKeyPair();
-  let sdk;
+  let aeSdk;
 
   before(async () => {
     await fs.outputFile(fileName, fileData);
-    sdk = await getSdk();
+    aeSdk = await getSdk();
   });
 
   it('Create Wallet', async () => {
@@ -46,7 +46,7 @@ Address _________________________________ ${resJson.publicKey}
 
   it('Check Wallet Address', async () => {
     expect((await executeAccount('address', WALLET_NAME, '--json')).publicKey)
-      .to.equal(sdk.address);
+      .to.equal(aeSdk.address);
   });
 
   it('Check Wallet Address with Private Key', async () => {
@@ -77,10 +77,10 @@ Secret Key ______________________________ ${keypair.secretKey}
   it('Sign message', async () => {
     const data = 'Hello world';
     const signedMessage = await executeAccount('sign-message', WALLET_NAME, data, '--json', '--password', 'test');
-    const signedUsingSDK = Array.from(await sdk.signMessage(data));
+    const signedUsingSDK = Array.from(await aeSdk.signMessage(data));
     sig = signedMessage.signatureHex;
     signedMessage.data.should.be.equal(data);
-    signedMessage.address.should.be.equal(sdk.address);
+    signedMessage.address.should.be.equal(aeSdk.address);
     Array.isArray(signedMessage.signature).should.be.equal(true);
     signedMessage.signature.toString().should.be.equal(signedUsingSDK.toString());
     signedMessage.signatureHex.should.be.a('string');
@@ -90,20 +90,20 @@ Secret Key ______________________________ ${keypair.secretKey}
     const {
       data, signature, signatureHex, address,
     } = await executeAccount('sign-message', WALLET_NAME, '--json', '--filePath', fileName, '--password', 'test');
-    const signedUsingSDK = Array.from(await sdk.signMessage(data));
+    const signedUsingSDK = Array.from(await aeSdk.signMessage(data));
     sigFromFile = signatureHex;
     signature.toString().should.be.equal(signedUsingSDK.toString());
     data.toString().should.be.equal(Array.from(Buffer.from(fileData)).toString());
-    address.should.be.equal(sdk.address);
+    address.should.be.equal(aeSdk.address);
     Array.isArray(signature).should.be.equal(true);
     signatureHex.should.be.a('string');
   });
 
   it('verify message', async () => {
     const data = 'Hello world';
-    const verify = await executeAccount('verify-message', sdk.address, sig, data, '--json');
+    const verify = await executeAccount('verify-message', aeSdk.address, sig, data, '--json');
     verify.isCorrect.should.be.equal(true);
-    const verifyFromFile = await executeAccount('verify-message', sdk.address, sigFromFile, '--json', '--filePath', fileName);
+    const verifyFromFile = await executeAccount('verify-message', aeSdk.address, sigFromFile, '--json', '--filePath', fileName);
     verifyFromFile.isCorrect.should.be.equal(true);
   });
 });

--- a/test/chain.js
+++ b/test/chain.js
@@ -5,12 +5,12 @@ import { executeProgram, getSdk } from './index.js';
 const executeChain = executeProgram.bind(null, 'chain');
 
 describe('Chain Module', () => {
-  let sdk;
+  let aeSdk;
 
   before(async () => {
-    sdk = await getSdk();
+    aeSdk = await getSdk();
     for (let i = 0; i < 5; i += 1) {
-      await sdk.spend(0, sdk.address); // eslint-disable-line no-await-in-loop
+      await aeSdk.spend(0, aeSdk.address); // eslint-disable-line no-await-in-loop
     }
   });
 
@@ -82,7 +82,7 @@ Syncing _________________________________ false
   });
 
   it('plays by height', async () => {
-    const res = await executeChain('play', '--height', await sdk.getHeight() - 4);
+    const res = await executeChain('play', '--height', await aeSdk.getHeight() - 4);
     const heights = res
       .split('\n')
       .filter((l) => l.includes('Block height'))
@@ -91,7 +91,7 @@ Syncing _________________________________ false
   });
 
   it('calculates ttl', async () => {
-    const height = await sdk.getHeight();
+    const height = await aeSdk.getHeight();
     const resJson = await executeChain('ttl', 10, '--json');
     expect(resJson).to.eql({
       absoluteTtl: 10,

--- a/test/contract.js
+++ b/test/contract.js
@@ -14,15 +14,15 @@ describe('Contract Module', function contractTests() {
   const contractSourceFile = 'test/contracts/contract.aes';
   const contractAciFile = 'test-artifacts/contract-aci.json';
   let deployDescriptorFile;
-  let sdk;
+  let aeSdk;
   let contractBytecode;
   let contractAddress;
 
   before(async () => {
-    sdk = await getSdk();
+    aeSdk = await getSdk();
     await fs.outputJson(
       contractAciFile,
-      (await sdk.compilerApi.compile(contractSourceFile)).aci,
+      (await aeSdk.compilerApi.compile(contractSourceFile)).aci,
     );
   });
 
@@ -168,7 +168,7 @@ describe('Contract Module', function contractTests() {
         '--amount',
         '1',
       );
-      expect(await sdk.getBalance(address)).to.be.equal('1');
+      expect(await aeSdk.getBalance(address)).to.be.equal('1');
     });
   });
 
@@ -322,7 +322,7 @@ describe('Contract Module', function contractTests() {
         '--amount',
         '0.000000001ae',
       );
-      expect(await sdk.getBalance(contractAddress)).to.be.equal('1000000000');
+      expect(await aeSdk.getBalance(contractAddress)).to.be.equal('1000000000');
     });
   });
 

--- a/test/inspect.js
+++ b/test/inspect.js
@@ -9,24 +9,24 @@ const executeInspect = executeProgram.bind(null, 'inspect');
 const executeChain = executeProgram.bind(null, 'chain');
 
 describe('Inspect Module', () => {
-  let sdk;
+  let aeSdk;
 
   before(async () => {
-    sdk = await getSdk();
+    aeSdk = await getSdk();
   });
 
   it('Inspect Account', async () => {
-    const balance = await sdk.getBalance(sdk.address);
-    const resJson = await executeInspect(sdk.address, '--json');
+    const balance = await aeSdk.getBalance(aeSdk.address);
+    const resJson = await executeInspect(aeSdk.address, '--json');
     expect(resJson).to.eql({
       balance,
-      hash: sdk.address,
+      hash: aeSdk.address,
       nonce: resJson.nonce,
       transactions: [],
     });
-    const res = await executeInspect(sdk.address);
+    const res = await executeInspect(aeSdk.address);
     expect(res).to.equal(`
-Account ID ______________________________ ${sdk.address}
+Account ID ______________________________ ${aeSdk.address}
 Account balance _________________________ 50ae
 Account nonce ___________________________ ${resJson.nonce}
 No pending transactions
@@ -36,7 +36,7 @@ No pending transactions
   it('Inspect Transaction Hash', async () => {
     const recipient = (generateKeyPair()).publicKey;
     const amount = '420';
-    const { hash } = await sdk.spend(amount, recipient);
+    const { hash } = await aeSdk.spend(amount, recipient);
     const resJson = await executeInspect(hash, '--json');
     expect(resJson.tx.fee).to.be.a('string');
     expect(resJson).to.eql({
@@ -47,7 +47,7 @@ No pending transactions
       signatures: [resJson.signatures[0]],
       tx: {
         recipientId: recipient,
-        senderId: sdk.address,
+        senderId: aeSdk.address,
         amount,
         fee: resJson.tx.fee,
         nonce: resJson.tx.nonce,
@@ -64,7 +64,7 @@ No pending transactions
       `Block height ____________________________ ${resJson.blockHeight} (about now)`,
       `Signatures ______________________________ ["${resJson.signatures[0]}"]`,
       'Transaction type ________________________ SpendTx (ver. 1)',
-      `Sender address __________________________ ${sdk.address}`,
+      `Sender address __________________________ ${aeSdk.address}`,
       `Recipient address _______________________ ${recipient}`,
       'Amount __________________________________ 0.00000000000000042ae',
       'Payload _________________________________ ba_Xfbg4g==',
@@ -77,8 +77,8 @@ No pending transactions
   it('Inspect Transaction', async () => {
     const recipientId = (generateKeyPair()).publicKey;
     const amount = '420';
-    const tx = await sdk.buildTx({
-      tag: Tag.SpendTx, amount, recipientId, senderId: sdk.address,
+    const tx = await aeSdk.buildTx({
+      tag: Tag.SpendTx, amount, recipientId, senderId: aeSdk.address,
     });
     const resJson = await executeInspect(tx, '--json');
     expect(resJson).to.eql({
@@ -87,7 +87,7 @@ No pending transactions
       nonce: resJson.nonce,
       payload: 'ba_Xfbg4g==',
       recipientId,
-      senderId: sdk.address,
+      senderId: aeSdk.address,
       tag: Tag.SpendTx,
       ttl: 0,
       version: 1,
@@ -97,7 +97,7 @@ No pending transactions
 Tx Type _________________________________ SpendTx
 tag _____________________________________ 12
 version _________________________________ 1
-senderId ________________________________ ${sdk.address}
+senderId ________________________________ ${aeSdk.address}
 recipientId _____________________________ ${recipientId}
 amount __________________________________ 420
 fee _____________________________________ 16700000000000
@@ -175,7 +175,7 @@ Target __________________________________ N/A
   });
 
   it('Inspect Contract', async () => {
-    const contract = await sdk.initializeContract({
+    const contract = await aeSdk.initializeContract({
       sourceCode: `
 contract Identity =
   entrypoint foo() = "test"
@@ -188,14 +188,14 @@ contract Identity =
       active: true,
       deposit: '0',
       id: address,
-      ownerId: sdk.address,
+      ownerId: aeSdk.address,
       referrerIds: [],
       vmVersion: VmVersion.Fate3.toString(),
     });
     const res = await executeInspect(address);
     expect(res).to.equal(`
 id ______________________________________ ${address}
-ownerId _________________________________ ${sdk.address}
+ownerId _________________________________ ${aeSdk.address}
 vmVersion _______________________________ 8
 abiVersion ______________________________ 3
 active __________________________________ true
@@ -211,8 +211,8 @@ deposit _________________________________ 0
   });
 
   it('Inspect Oracle', async () => {
-    const { id: oracleId } = await sdk.registerOracle('<request format>', '<response format>');
-    const { id: queryId } = await sdk.postQueryToOracle(oracleId, 'Hello?');
+    const { id: oracleId } = await aeSdk.registerOracle('<request format>', '<response format>');
+    const { id: queryId } = await aeSdk.postQueryToOracle(oracleId, 'Hello?');
     const resJson = await executeInspect(oracleId, '--json');
     expect(resJson).to.eql({
       id: oracleId,
@@ -227,7 +227,7 @@ deposit _________________________________ 0
           type: 'delta',
           value: '10',
         },
-        senderId: sdk.address,
+        senderId: aeSdk.address,
         senderNonce: '4',
         ttl: resJson.queries[0].ttl,
       }],
@@ -254,7 +254,7 @@ Query decoded ___________________________ Hello?
 Response ________________________________ or_Xfbg4g==
 Response decoded ________________________${' '}
 Response Ttl ____________________________ {"type":"delta","value":"10"}
-Sender Id _______________________________ ${sdk.address}
+Sender Id _______________________________ ${aeSdk.address}
 Sender Nonce ____________________________ 4
 Ttl _____________________________________ ${resJson.queries[0].ttl}
 ------------------------------------------------------------------------------
@@ -281,19 +281,19 @@ Name hash _______________________________ ${produceNameId(name)}
   });
 
   it('Inspect Claimed Name', async () => {
-    await (await (await sdk.aensPreclaim(name)).claim()).update({
-      myKey: sdk.address,
-      account_pubkey: sdk.address,
-      oracle_pubkey: sdk.address,
+    await (await (await aeSdk.aensPreclaim(name)).claim()).update({
+      myKey: aeSdk.address,
+      account_pubkey: aeSdk.address,
+      oracle_pubkey: aeSdk.address,
     });
     const resJson = await executeInspect(name, '--json');
     expect(resJson).to.eql({
       id: resJson.id,
-      owner: sdk.address,
+      owner: aeSdk.address,
       pointers: [
-        { id: sdk.address, key: 'myKey' },
-        { id: sdk.address, key: 'account_pubkey' },
-        { id: sdk.address, key: 'oracle_pubkey' },
+        { id: aeSdk.address, key: 'myKey' },
+        { id: aeSdk.address, key: 'account_pubkey' },
+        { id: aeSdk.address, key: 'oracle_pubkey' },
       ],
       status: 'CLAIMED',
       ttl: resJson.ttl,
@@ -302,23 +302,23 @@ Name hash _______________________________ ${produceNameId(name)}
     expectToMatchLines(res, [
       'Status __________________________________ CLAIMED',
       `Name hash _______________________________ ${resJson.id}`,
-      `Owner ___________________________________ ${sdk.address}`,
-      `Pointer myKey ___________________________ ${sdk.address}`,
-      `Pointer account_pubkey __________________ ${sdk.address}`,
-      `Pointer oracle_pubkey ___________________ ${sdk.address}`,
+      `Owner ___________________________________ ${aeSdk.address}`,
+      `Pointer myKey ___________________________ ${aeSdk.address}`,
+      `Pointer account_pubkey __________________ ${aeSdk.address}`,
+      `Pointer oracle_pubkey ___________________ ${aeSdk.address}`,
       /TTL _____________________________________ \d+ \(in 1 year\)/,
     ]);
   }).timeout(6000);
 
   it('Inspect Running Auction Name', async () => {
     const auctionName = `a${Math.random().toString().slice(2, 9)}.chain`;
-    await (await sdk.aensPreclaim(auctionName)).claim();
+    await (await aeSdk.aensPreclaim(auctionName)).claim();
     const resJson = await executeInspect(auctionName, '--json');
     const endsAt = +resJson.startedAt + 960;
     expect(resJson).to.eql({
       endsAt: String(endsAt),
       highestBid: '19641800000000000000',
-      highestBidder: sdk.address,
+      highestBidder: aeSdk.address,
       id: resJson.id,
       startedAt: resJson.startedAt,
       status: 'AUCTION',
@@ -327,7 +327,7 @@ Name hash _______________________________ ${produceNameId(name)}
     expect(res).to.equal(`
 Status __________________________________ AUCTION
 Name hash _______________________________ ${resJson.id}
-Highest bidder __________________________ ${sdk.address}
+Highest bidder __________________________ ${aeSdk.address}
 Highest bid _____________________________ 19.6418ae
 Ends at height __________________________ ${endsAt} (in 1 day)
 Started at height _______________________ ${resJson.startedAt} (about now)

--- a/test/name.js
+++ b/test/name.js
@@ -13,11 +13,11 @@ describe('AENS Module', () => {
   const { publicKey } = generateKeyPair();
   const name = randomName(12);
   const name2 = randomName(13);
-  let sdk;
+  let aeSdk;
   let salt;
 
   before(async () => {
-    sdk = await getSdk();
+    aeSdk = await getSdk();
   });
 
   it('Full claim', async () => {
@@ -31,8 +31,8 @@ describe('AENS Module', () => {
     );
 
     updateTx.blockHeight.should.be.gt(0);
-    const pointer = updateTx.pointers.find(({ id }) => id === sdk.address);
-    expect(pointer).to.be.eql({ id: sdk.address, key: 'account_pubkey' });
+    const pointer = updateTx.pointers.find(({ id }) => id === aeSdk.address);
+    expect(pointer).to.be.eql({ id: aeSdk.address, key: 'account_pubkey' });
   }).timeout(10000);
 
   it('Full claim with options', async () => {
@@ -54,8 +54,8 @@ describe('AENS Module', () => {
     updateTx.blockHeight.should.be.gt(0);
     updateTx.tx.nameTtl.should.be.equal(50);
     updateTx.tx.clientTtl.should.be.equal(50);
-    const pointer = updateTx.pointers.find(({ id }) => id === sdk.address);
-    expect(pointer).to.be.eql({ id: sdk.address, key: 'account_pubkey' });
+    const pointer = updateTx.pointers.find(({ id }) => id === aeSdk.address);
+    expect(pointer).to.be.eql({ id: aeSdk.address, key: 'account_pubkey' });
   }).timeout(10000);
 
   it('Pre Claim Name', async () => {
@@ -115,7 +115,7 @@ describe('AENS Module', () => {
   });
 
   it('extend name ttl', async () => {
-    const height = await sdk.getHeight();
+    const height = await aeSdk.getHeight();
     const extendTx = await executeName(
       'extend',
       WALLET_NAME,
@@ -160,9 +160,9 @@ describe('AENS Module', () => {
       '--json',
     );
 
-    const nameObject = await sdk.aensQuery(name2);
+    const nameObject = await aeSdk.aensQuery(name2);
     recipientId.should.be.equal(nameObject.id);
-    const balance = await sdk.getBalance(publicKey);
+    const balance = await aeSdk.getBalance(publicKey);
     balance.should.be.equal(`${amount}`);
   });
 
@@ -180,10 +180,10 @@ describe('AENS Module', () => {
     );
 
     transferTx.blockHeight.should.be.gt(0);
-    await sdk.spend(1, keypair.publicKey, { denomination: 'ae' });
-    const claim2 = await sdk.aensQuery(name2);
+    await aeSdk.spend(1, keypair.publicKey, { denomination: 'ae' });
+    const claim2 = await aeSdk.aensQuery(name2);
     const transferBack = await claim2
-      .transfer(sdk.address, { onAccount: new MemoryAccount(keypair.secretKey) });
+      .transfer(aeSdk.address, { onAccount: new MemoryAccount(keypair.secretKey) });
     transferBack.blockHeight.should.be.gt(0);
   });
 
@@ -219,8 +219,8 @@ describe('AENS Module', () => {
 
     it('Open auction', async () => {
       const onAccount = MemoryAccount.generate();
-      await sdk.spend(5e18, onAccount.address);
-      const preclaim = await sdk.aensPreclaim(name, { onAccount });
+      await aeSdk.spend(5e18, onAccount.address);
+      const preclaim = await aeSdk.aensPreclaim(name, { onAccount });
       const claim = await preclaim.claim({ onAccount });
       claim.blockHeight.should.be.gt(0);
     }).timeout(10000);

--- a/test/oracle.js
+++ b/test/oracle.js
@@ -7,12 +7,12 @@ const executeOracle = executeProgram.bind(null, 'oracle');
 describe('Oracle Module', () => {
   const oracleFormat = 'string';
   const responseFormat = 'string';
-  let sdk;
+  let aeSdk;
   let oracleId;
   let queryId;
 
   before(async () => {
-    sdk = await getSdk();
+    aeSdk = await getSdk();
   });
 
   it('Oracle create', async () => {
@@ -35,7 +35,7 @@ describe('Oracle Module', () => {
   });
 
   it('Oracle extend', async () => {
-    const oracle = await sdk.getOracleObject(oracleId);
+    const oracle = await aeSdk.getOracleObject(oracleId);
     const oracleExtend = await executeOracle('extend', WALLET_NAME, '--password', 'test', 42, '--json');
     oracleExtend.blockHeight.should.be.gt(0);
     expect(oracleExtend.ttl).to.be.equal(oracle.ttl + 42);
@@ -61,7 +61,7 @@ describe('Oracle Module', () => {
     oracleQuery.decodedQuery.should.be.equal('Hello?');
     oracleQuery.id.split('_')[0].should.be.equal('oq');
     queryId = oracleQuery.id;
-    const oracle = await sdk.getOracleObject(oracleId);
+    const oracle = await aeSdk.getOracleObject(oracleId);
     oracle.queries.length.should.be.equal(1);
   });
 
@@ -79,7 +79,7 @@ describe('Oracle Module', () => {
     );
     expect(oracleQueryResponse.queries[0].ttl).to.be.equal(oracleQueryResponse.blockHeight + 21);
     oracleQueryResponse.blockHeight.should.be.gt(0);
-    const oracle = await sdk.getOracleObject(oracleId);
+    const oracle = await aeSdk.getOracleObject(oracleId);
     const query = await oracle.getQuery(queryId);
     query.decodedResponse.should.be.equal('Hi!');
   });

--- a/test/spend.js
+++ b/test/spend.js
@@ -8,17 +8,17 @@ import {
 const executeSpend = executeProgram.bind(null, 'spend', WALLET_NAME, '--password', 'test');
 
 describe('Spend', () => {
-  let sdk;
+  let aeSdk;
 
   before(async () => {
-    sdk = await getSdk();
+    aeSdk = await getSdk();
   });
 
   it('spends', async () => {
     const amount = 100;
     const { publicKey } = generateKeyPair();
     const resJson = await executeSpend(publicKey, amount, '--json');
-    const receiverBalance = await sdk.getBalance(publicKey);
+    const receiverBalance = await aeSdk.getBalance(publicKey);
     expect(+receiverBalance).to.be.equal(amount);
 
     expect(resJson.tx.fee).to.be.a('string');
@@ -63,19 +63,19 @@ describe('Spend', () => {
   it('spends in ae', async () => {
     const receiverKeys = generateKeyPair();
     const { tx: { fee } } = await executeSpend('--json', receiverKeys.publicKey, '1ae', '--fee', '0.02ae');
-    expect(await sdk.getBalance(receiverKeys.publicKey)).to.be.equal('1000000000000000000');
+    expect(await aeSdk.getBalance(receiverKeys.publicKey)).to.be.equal('1000000000000000000');
     expect(fee).to.be.equal('20000000000000000');
   });
 
   it('spends percent of balance', async () => {
     const { publicKey } = generateKeyPair();
-    const balanceBefore = await sdk.getBalance(sdk.address);
+    const balanceBefore = await aeSdk.getBalance(aeSdk.address);
     await executeSpend(publicKey, '42%');
-    expect(+await sdk.getBalance(publicKey)).to.be.equal(balanceBefore * 0.42);
+    expect(+await aeSdk.getBalance(publicKey)).to.be.equal(balanceBefore * 0.42);
   });
 
   it('spends to contract', async () => {
-    const contract = await sdk.initializeContract({
+    const contract = await aeSdk.initializeContract({
       sourceCode: ''
         + 'payable contract Main =\n'
         + '  record state = { key: int }\n'
@@ -83,6 +83,6 @@ describe('Spend', () => {
     });
     const { address } = await contract.$deploy([]);
     await executeSpend(address, 100);
-    expect(await sdk.getBalance(address)).to.be.equal('100');
+    expect(await aeSdk.getBalance(address)).to.be.equal('100');
   });
 });

--- a/test/tx.js
+++ b/test/tx.js
@@ -17,7 +17,7 @@ contract Identity =
 `;
 
 describe('Transaction Module', () => {
-  let sdk;
+  let aeSdk;
   let oracleId;
   let salt;
   let queryId;
@@ -27,14 +27,14 @@ describe('Transaction Module', () => {
   let nameId;
 
   before(async () => {
-    sdk = await getSdk();
-    oracleId = encode(decode(sdk.address, Encoding.AccountAddress), Encoding.OracleAddress);
+    aeSdk = await getSdk();
+    oracleId = encode(decode(aeSdk.address, Encoding.AccountAddress), Encoding.OracleAddress);
   });
 
   it('builds tx', async () => {
     const amount = 100;
 
-    const args = ['spend', sdk.address, sdk.address, amount, nonce];
+    const args = ['spend', aeSdk.address, aeSdk.address, amount, nonce];
     const responseJson = await executeTx(...args, '--json');
     expect(responseJson.tx).to.satisfy((s) => s.startsWith(Encoding.Transaction));
     expect(responseJson).to.eql({
@@ -45,8 +45,8 @@ describe('Transaction Module', () => {
         fee: '16660000000000',
         nonce,
         payload: 'ba_Xfbg4g==',
-        recipientId: sdk.address,
-        senderId: sdk.address,
+        recipientId: aeSdk.address,
+        senderId: aeSdk.address,
         tag: 12,
         ttl: 0,
       },
@@ -58,8 +58,8 @@ Transaction type ________________________ SpendTx
 Summary
     TAG _________________________________ 12
     VERSION _____________________________ 1
-    SENDERID ____________________________ ${sdk.address}
-    RECIPIENTID _________________________ ${sdk.address}
+    SENDERID ____________________________ ${aeSdk.address}
+    RECIPIENTID _________________________ ${aeSdk.address}
     AMOUNT ______________________________ ${amount}
     FEE _________________________________ 16660000000000
     TTL _________________________________ 0
@@ -72,20 +72,20 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
   });
 
   it('signs tx', async () => {
-    const { tx } = await executeTx('spend', sdk.address, sdk.address, 100, nonce, '--json');
+    const { tx } = await executeTx('spend', aeSdk.address, aeSdk.address, 100, nonce, '--json');
 
     const args = ['sign', WALLET_NAME, tx, '--password', 'test', '--networkId', networkId];
     const responseJson = await executeProgram('account', ...args, '--json');
     expect(responseJson.signedTx).to.satisfy((s) => s.startsWith(Encoding.Transaction));
     expect(responseJson).to.eql({
-      address: sdk.address,
+      address: aeSdk.address,
       networkId: 'ae_dev',
       signedTx: responseJson.signedTx,
     });
 
     const response = await executeProgram('account', ...args);
     expectToMatchLines(response, [
-      `Signing account address _________________ ${sdk.address}`,
+      `Signing account address _________________ ${aeSdk.address}`,
       'Network ID ______________________________ ae_dev',
       `Unsigned ________________________________ ${tx}`,
       `Signed __________________________________ ${responseJson.signedTx}`,
@@ -124,7 +124,7 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
   it('builds spend tx and sends', async () => {
     const amount = 100;
     nonce += 1;
-    const { tx } = await executeTx('spend', sdk.address, sdk.address, amount, nonce, '--json');
+    const { tx } = await executeTx('spend', aeSdk.address, aeSdk.address, amount, nonce, '--json');
 
     const [detailsJson, details] = await signAndPostAndInspect(tx);
     expect(detailsJson.fee).to.be.a('string');
@@ -133,15 +133,15 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
       fee: detailsJson.fee,
       nonce,
       payload: 'ba_Xfbg4g==',
-      recipientId: sdk.address,
-      senderId: sdk.address,
+      recipientId: aeSdk.address,
+      senderId: aeSdk.address,
       type: 'SpendTx',
       version: 1,
     });
     expectToMatchLines(details, [
       'Transaction type ________________________ SpendTx (ver. 1)',
-      `Sender address __________________________ ${sdk.address}`,
-      `Recipient address _______________________ ${sdk.address}`,
+      `Sender address __________________________ ${aeSdk.address}`,
+      `Recipient address _______________________ ${aeSdk.address}`,
       'Amount __________________________________ 0.0000000000000001ae',
       'Payload _________________________________ ba_Xfbg4g==',
       /Fee _____________________________________ 0.000016\d+ae/,
@@ -151,14 +151,14 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
 
   it('builds name preclaim tx and sends', async () => {
     nonce += 1;
-    const { tx, salt: nameSalt } = await executeTx('name-preclaim', sdk.address, name, nonce, '--json');
+    const { tx, salt: nameSalt } = await executeTx('name-preclaim', aeSdk.address, name, nonce, '--json');
     salt = nameSalt;
 
     const [detailsJson, details] = await signAndPostAndInspect(tx);
     expect(detailsJson.commitmentId).to.satisfy((s) => s.startsWith(Encoding.Commitment));
     expect(detailsJson.fee).to.be.a('string');
     expect(detailsJson).to.eql({
-      accountId: sdk.address,
+      accountId: aeSdk.address,
       commitmentId: detailsJson.commitmentId,
       fee: detailsJson.fee,
       nonce,
@@ -167,7 +167,7 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
     });
     expectToMatchLines(details, [
       'Transaction type ________________________ NamePreclaimTx (ver. 1)',
-      `Account address _________________________ ${sdk.address}`,
+      `Account address _________________________ ${aeSdk.address}`,
       `Commitment ______________________________ ${detailsJson.commitmentId}`,
       /Fee _____________________________________ 0.000016\d+ae/,
       `Nonce ___________________________________ ${nonce}`,
@@ -176,13 +176,13 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
 
   it('builds name claim tx and sends', async () => {
     nonce += 1;
-    const { tx } = await executeTx('name-claim', sdk.address, salt, name, nonce, '--json');
+    const { tx } = await executeTx('name-claim', aeSdk.address, salt, name, nonce, '--json');
 
     const [detailsJson, details] = await signAndPostAndInspect(tx);
     expect(detailsJson.nameSalt).to.be.a('number');
     expect(detailsJson.fee).to.be.a('string');
     expect(detailsJson).to.eql({
-      accountId: sdk.address,
+      accountId: aeSdk.address,
       fee: detailsJson.fee,
       name,
       nameFee: '159700000000000000',
@@ -193,7 +193,7 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
     });
     expectToMatchLines(details, [
       'Transaction type ________________________ NameClaimTx (ver. 2)',
-      `Account address _________________________ ${sdk.address}`,
+      `Account address _________________________ ${aeSdk.address}`,
       `Name ____________________________________ ${name}`,
       'Name fee ________________________________ 0.1597ae',
       `Name salt _______________________________ ${salt}`,
@@ -201,12 +201,12 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
       `Nonce ___________________________________ ${nonce}`,
     ]);
 
-    nameId = (await sdk.aensQuery(name)).id;
+    nameId = (await aeSdk.aensQuery(name)).id;
   }).timeout(10000);
 
   it('builds name update tx and sends', async () => {
     nonce += 1;
-    const { tx } = await executeTx('name-update', sdk.address, nameId, nonce, sdk.address, '--json');
+    const { tx } = await executeTx('name-update', aeSdk.address, nameId, nonce, aeSdk.address, '--json');
 
     const [detailsJson, details] = await signAndPostAndInspect(tx);
     expect(detailsJson.fee).to.be.a('string');
@@ -216,17 +216,17 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
       nameId,
       nameTtl: 180000,
       nonce,
-      pointers: [{ id: sdk.address, key: 'account_pubkey' }],
+      pointers: [{ id: aeSdk.address, key: 'account_pubkey' }],
       type: 'NameUpdateTx',
       version: 1,
-      accountId: sdk.address,
+      accountId: aeSdk.address,
     });
     expectToMatchLines(details, [
       'Transaction type ________________________ NameUpdateTx (ver. 1)',
-      `Account address _________________________ ${sdk.address}`,
+      `Account address _________________________ ${aeSdk.address}`,
       `Name ID _________________________________ ${nameId}`,
       'Name TTL ________________________________ 180000 (in 1 year)',
-      `Pointer account_pubkey __________________ ${sdk.address}`,
+      `Pointer account_pubkey __________________ ${aeSdk.address}`,
       'Client TTL ______________________________ 3600 (1 hour)',
       /Fee _____________________________________ 0.000017\d+ae/,
       `Nonce ___________________________________ ${nonce}`,
@@ -235,7 +235,7 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
 
   it('builds name transfer tx and sends', async () => {
     nonce += 1;
-    const { tx } = await executeTx('name-transfer', sdk.address, sdk.address, nameId, nonce, '--json');
+    const { tx } = await executeTx('name-transfer', aeSdk.address, aeSdk.address, nameId, nonce, '--json');
 
     const [detailsJson, details] = await signAndPostAndInspect(tx);
     expect(detailsJson.fee).to.be.a('string');
@@ -243,15 +243,15 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
       fee: detailsJson.fee,
       nameId,
       nonce,
-      recipientId: sdk.address,
+      recipientId: aeSdk.address,
       type: 'NameTransferTx',
       version: 1,
-      accountId: sdk.address,
+      accountId: aeSdk.address,
     });
     expectToMatchLines(details, [
       'Transaction type ________________________ NameTransferTx (ver. 1)',
-      `Account address _________________________ ${sdk.address}`,
-      `Recipient address _______________________ ${sdk.address}`,
+      `Account address _________________________ ${aeSdk.address}`,
+      `Recipient address _______________________ ${aeSdk.address}`,
       `Name ID _________________________________ ${nameId}`,
       /Fee _____________________________________ 0.000017\d+ae/,
       `Nonce ___________________________________ ${nonce}`,
@@ -260,7 +260,7 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
 
   it('builds name revoke tx and sends', async () => {
     nonce += 1;
-    const { tx } = await executeTx('name-revoke', sdk.address, nameId, nonce, '--json');
+    const { tx } = await executeTx('name-revoke', aeSdk.address, nameId, nonce, '--json');
 
     const [detailsJson, details] = await signAndPostAndInspect(tx);
     expect(detailsJson.fee).to.be.a('string');
@@ -270,11 +270,11 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
       nonce,
       type: 'NameRevokeTx',
       version: 1,
-      accountId: sdk.address,
+      accountId: aeSdk.address,
     });
     expectToMatchLines(details, [
       'Transaction type ________________________ NameRevokeTx (ver. 1)',
-      `Account address _________________________ ${sdk.address}`,
+      `Account address _________________________ ${aeSdk.address}`,
       `Name ID _________________________________ ${nameId}`,
       /Fee _____________________________________ 0.000016\d+ae/,
       `Nonce ___________________________________ ${nonce}`,
@@ -284,13 +284,13 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
   let contract;
   it('builds contract create tx and sends', async () => {
     nonce += 1;
-    contract = await sdk.initializeContract({ sourceCode: testContract });
+    contract = await aeSdk.initializeContract({ sourceCode: testContract });
     const bytecode = await contract.$compile();
     // eslint-disable-next-line no-underscore-dangle
     const callData = contract._calldata.encode(contract._name, 'init', []);
     const { tx, contractId: cId } = await executeTx(
       'contract-deploy',
-      sdk.address,
+      aeSdk.address,
       bytecode,
       callData,
       nonce,
@@ -313,11 +313,11 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
       nonce,
       type: 'ContractCreateTx',
       version: 1,
-      ownerId: sdk.address,
+      ownerId: aeSdk.address,
     });
     expectToMatchLines(details, [
       'Transaction type ________________________ ContractCreateTx (ver. 1)',
-      `Owner address ___________________________ ${sdk.address}`,
+      `Owner address ___________________________ ${aeSdk.address}`,
       'Gas _____________________________________ 5921420 (0.00592142ae)',
       'Gas price _______________________________ 0.000000001ae',
       `Bytecode ________________________________ ${bytecode}`,
@@ -334,7 +334,7 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
     nonce += 1;
     // eslint-disable-next-line no-underscore-dangle
     const callData = contract._calldata.encode(contract._name, 'test', ['1', '2']);
-    const { tx } = await executeTx('contract-call', sdk.address, contractId, callData, nonce, '--json', '--amount', '0.00000042ae');
+    const { tx } = await executeTx('contract-call', aeSdk.address, contractId, callData, nonce, '--json', '--amount', '0.00000042ae');
 
     const [detailsJson, details] = await signAndPostAndInspect(tx);
     expect(detailsJson.fee).to.be.a('string');
@@ -342,7 +342,7 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
       abiVersion: '3',
       amount: '420000000000',
       callData,
-      callerId: sdk.address,
+      callerId: aeSdk.address,
       contractId,
       fee: detailsJson.fee,
       gas: 5817860,
@@ -353,7 +353,7 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
     });
     expectToMatchLines(details, [
       'Transaction type ________________________ ContractCallTx (ver. 1)',
-      `Caller address __________________________ ${sdk.address}`,
+      `Caller address __________________________ ${aeSdk.address}`,
       `Contract address ________________________ ${contractId}`,
       'Gas _____________________________________ 5817860 (0.00581786ae)',
       'Gas price _______________________________ 0.000000001ae',
@@ -367,13 +367,13 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
 
   it('builds oracle register tx and sends', async () => {
     nonce += 1;
-    const { tx } = await executeTx('oracle-register', sdk.address, '{city: "str"}', '{tmp:""num}', nonce, '--json');
+    const { tx } = await executeTx('oracle-register', aeSdk.address, '{city: "str"}', '{tmp:""num}', nonce, '--json');
 
     const [detailsJson, details] = await signAndPostAndInspect(tx);
     expect(detailsJson.fee).to.be.a('string');
     expect(detailsJson).to.eql({
       abiVersion: '0',
-      accountId: sdk.address,
+      accountId: aeSdk.address,
       fee: detailsJson.fee,
       nonce,
       oracleTtl: { type: 'delta', value: '500' },
@@ -385,7 +385,7 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
     });
     expectToMatchLines(details, [
       'Transaction type ________________________ OracleRegisterTx (ver. 1)',
-      `Account address _________________________ ${sdk.address}`,
+      `Account address _________________________ ${aeSdk.address}`,
       /Oracle TTL ______________________________ \d+ \(in 1 day\)/,
       'ABI version _____________________________ 0 (NoAbi)',
       'Query fee _______________________________ 0ae',
@@ -397,7 +397,7 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
   });
 
   it('builds oracle extend tx and sends', async () => {
-    const oracleCurrentTtl = await sdk.api.getOracleByPubkey(oracleId);
+    const oracleCurrentTtl = await aeSdk.api.getOracleByPubkey(oracleId);
     nonce += 1;
     const { tx } = await executeTx('oracle-extend', oracleId, 100, nonce, '--json');
 
@@ -419,14 +419,14 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
       `Nonce ___________________________________ ${nonce}`,
     ]);
 
-    const oracleTtl = await sdk.api.getOracleByPubkey(oracleId);
+    const oracleTtl = await aeSdk.api.getOracleByPubkey(oracleId);
     const isExtended = +oracleTtl.ttl === +oracleCurrentTtl.ttl + 100;
     isExtended.should.be.equal(true);
   });
 
   it('builds oracle post query tx and sends', async () => {
     nonce += 1;
-    const { tx } = await executeTx('oracle-post-query', sdk.address, oracleId, '{city: "Berlin"}', nonce, '--json');
+    const { tx } = await executeTx('oracle-post-query', aeSdk.address, oracleId, '{city: "Berlin"}', nonce, '--json');
 
     const [detailsJson, details] = await signAndPostAndInspect(tx);
     expect(detailsJson.fee).to.be.a('string');
@@ -438,13 +438,13 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
       queryFee: '0',
       queryTtl: { type: 'delta', value: '10' },
       responseTtl: { type: 'delta', value: '10' },
-      senderId: sdk.address,
+      senderId: aeSdk.address,
       type: 'OracleQueryTx',
       version: 1,
     });
     expectToMatchLines(details, [
       'Transaction type ________________________ OracleQueryTx (ver. 1)',
-      `Sender address __________________________ ${sdk.address}`,
+      `Sender address __________________________ ${aeSdk.address}`,
       `Oracle ID _______________________________ ${oracleId}`,
       'Query ___________________________________ {city: "Berlin"}',
       'Query fee _______________________________ 0ae',
@@ -454,7 +454,7 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
       `Nonce ___________________________________ ${nonce}`,
     ]);
 
-    const { oracleQueries: queries } = await sdk.api.getOracleQueriesByPubkey(oracleId);
+    const { oracleQueries: queries } = await aeSdk.api.getOracleQueriesByPubkey(oracleId);
     queryId = queries[0].id;
     const hasQuery = !!queries.length;
     hasQuery.should.be.equal(true);
@@ -487,7 +487,7 @@ This is an unsigned transaction. Use \`account sign\` and \`tx broadcast\` to su
       `Nonce ___________________________________ ${nonce}`,
     ]);
 
-    const { oracleQueries: queries } = await sdk.api.getOracleQueriesByPubkey(oracleId);
+    const { oracleQueries: queries } = await aeSdk.api.getOracleQueriesByPubkey(oracleId);
     const responseQuery = decode(queries[0].response).toString();
     const hasQuery = !!queries.length;
     hasQuery.should.be.equal(true);


### PR DESCRIPTION
This PR is supported by the Æternity Foundation