### PR TITLE
feat: show `aecli config` as table

### DIFF
--- a/src/commands/main.js
+++ b/src/commands/main.js
@@ -17,6 +17,7 @@ import { compilerOption, nodeOption } from '../arguments.js';
 import { getCompilerByUrl } from '../utils/cli.js';
 import { addToConfig } from '../utils/config.js';
 import CliError from '../utils/CliError.js';
+import { printTable } from '../utils/print.js';
 
 const program = new Command('aecli');
 
@@ -62,8 +63,10 @@ let command = program
   .addOption(nodeOption)
   .addOption(compilerOption)
   .action(async ({ url, compilerUrl }) => {
-    console.log('Node', url, await getNodeDescription(url));
-    console.log('Compiler', compilerUrl, await getCompilerDescription(compilerUrl));
+    printTable([
+      ['Node', url, await getNodeDescription(url)],
+      ['Compiler', compilerUrl, await getCompilerDescription(compilerUrl)],
+    ]);
   });
 addCommonOptions(command);
 

--- a/src/utils/print.js
+++ b/src/utils/print.js
@@ -32,12 +32,15 @@ export function print(msg, obj) {
 }
 
 export function printTable(data) {
-  const firstColumnWidth = Math.max(...data.map(([key]) => key.length));
-  for (const [key, val] of data) {
-    console.log(
-      key.padEnd(firstColumnWidth + 1),
-      typeof val !== 'object' ? val : JsonStringifyEs(val),
-    );
+  data = data.map((row) =>
+    row.map((cell) => (typeof cell !== 'object' ? String(cell) : JsonStringifyEs(cell))),
+  );
+  const columnCount = Math.max(...data.map((row) => row.length));
+  const columnWidths = new Array(columnCount - 1)
+    .fill()
+    .map((_, idx) => Math.max(...data.map((row) => row[idx].length)));
+  for (const row of data) {
+    console.log(...row.map((cell, idx) => cell.padEnd(columnWidths[idx] + 1)));
   }
 }
 

--- a/test/other.js
+++ b/test/other.js
@@ -5,8 +5,8 @@ import { executeProgram } from './index.js';
 describe('Other tests', () => {
   it('Config', async () => {
     expect(await executeProgram('config')).to.equal(
-      'Node https://mainnet.aeternity.io network id ae_mainnet, version 7.1.0, protocol 6 (Ceres)\n' +
-        'Compiler https://v8.compiler.aepps.com version 8.0.0',
+      'Node      https://mainnet.aeternity.io   network id ae_mainnet, version 7.2.0, protocol 6 (Ceres)\n' +
+        'Compiler  https://v8.compiler.aepps.com  version 8.0.0',
     );
   });
 


### PR DESCRIPTION
This PR is supported by the Æternity Foundation

```
$ aecli config
Node      https://mainnet.aeternity.io/   network id ae_mainnet, version 7.2.0, protocol 6 (Ceres)
Compiler  https://v8.compiler.aepps.com/  version 8.0.0
```